### PR TITLE
oxmux: Add routing policy primitives

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -30,6 +30,7 @@ clearly non-behavioral changes, provide a short no-spec-required justification.
 
 - OpenSpec change/spec: <!-- openspec/changes/... or openspec/specs/... -->
 - No OpenSpec required: <!-- reason, if applicable -->
+- Vision/boundary impact: <!-- If this touches subscription UX, auth/session behavior, request rewrite, model aliases, reasoning/thinking compatibility, routing, provider selection, or crate boundaries, explain how docs/vision.md and docs/architecture.md are preserved. -->
 
 ## 📖 Documentation Checklist
 
@@ -49,6 +50,7 @@ Please confirm that you have followed these guidelines.
 - [ ] My code follows the project's coding standards.
 - [ ] I have added a `.env.example` file if environment variables are needed and ensured no secrets are committed.
 - [ ] My pull request is focused on a single project or change.
+- [ ] I preserved the `oxmux` shared-core and `oxidemux` platform-shell boundary, or documented the OpenSpec-approved reason for changing it.
 - [ ] I ran `mise run ci` locally, or explained why it was not applicable.
 - [ ] I ran relevant hk checks with `mise run hk-check`, or explained why they were not applicable.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,15 @@
 # Rust coding guidelines
 
+# Product intent for agents
+
+* Preserve the core vision: OxideMux exists to provide subscription-aware local AI proxying with first-class Linux, macOS, and Windows support because VibeProxy and zero-limit validate the product shape but do not cover the full cross-platform need.
+* Treat subscription UX as the product center, not an add-on. Account health, auth state, quota pressure, provider availability, routing choices, fallback reasons, and recovery actions should remain visible to users and testable in core state.
+* Do not reduce VibeProxy, zero-limit, or CLIProxyAPI to vague inspiration. Treat them as validated product references: CLIProxyAPI for headless proxy/API boundaries, zero-limit for desktop lifecycle/quota UX, and VibeProxy for subscription-first local proxy auth, alias, routing, and thinking/reasoning rewrite behavior.
+* `oxmux` owns shared, headless semantics: protocol compatibility, request rewriting, model aliases, reasoning/thinking primitives, subscription-aware routing, provider/account state, usage/quota summaries, management snapshots, and structured errors.
+* `oxidemux` owns platform shell implementation: GPUI views, tray/menu integration, desktop lifecycle, notifications, packaging, updater UX, platform credential storage adapters, and OS-specific auth presentation.
+* If behavior must work in CLI/headless tests, put the semantics in `oxmux`. If behavior exists only because a desktop OS, GPUI, tray/menu, packaging, updater, or platform secret store exists, put it in `oxidemux` or an app-owned adapter.
+* Before changing subscription UX, auth/session behavior, request rewrite, thinking/reasoning compatibility, routing, provider selection, or crate boundaries, update or reference OpenSpec. See `docs/vision.md`, `docs/architecture.md`, `openspec/specs/oxmux-core/spec.md`, and `openspec/specs/oxidemux-app-shell/spec.md`.
+
 * Prioritize code correctness and clarity. Speed and efficiency are secondary priorities unless otherwise specified.
 * Do not write organizational or comments that summarize the code. Comments should only be written in order to explain "why" the code is written in some way in the case there is a reason that is tricky / non-obvious.
 * Prefer implementing functionality in existing files unless it is a new logical component. Avoid creating many small files.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,8 @@ Create or update OpenSpec artifacts before implementing changes that affect:
 - Public Rust APIs.
 - Workflow policy.
 - Provider or protocol semantics.
+- Subscription UX, provider auth/session semantics, model aliases, request
+  rewrite behavior, or reasoning/thinking compatibility.
 - GPUI behavior.
 - Cross-crate boundaries.
 
@@ -48,6 +50,10 @@ OpenSpec path in the pull request.
 No OpenSpec artifact is required for docs-only, typo-only, formatting-only,
 dependency-free housekeeping, or clearly non-behavioral changes. In those cases,
 add a short no-spec-required justification in the pull request template.
+
+Use `docs/vision.md` and `docs/architecture.md` as the durable product-intent
+guardrails. Changes that move behavior between `oxmux` and `oxidemux` must
+explain how they preserve the shared core versus platform shell boundary.
 
 ## Pull request hygiene
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ local AI subscription proxy and multiplexer. Its proxy and gateway direction is
 inspired by CLIProxyAPI, and its desktop control and monitoring direction is
 inspired by zero-limit.
 
+OxideMux exists because VibeProxy and zero-limit prove the subscription-aware
+local proxy experience is valuable, but this project needs that experience with
+first-class Linux, macOS, and Windows support. Subscription UX is the product
+center: account health, auth state, quota pressure, provider availability,
+routing choices, and recovery paths should be visible and controllable from one
+native app while remaining testable through a shared headless core.
+
 ## Status
 
 ### Completed
@@ -75,12 +82,17 @@ inspired by zero-limit.
 
 - `Cargo.toml`: Workspace manifest for all repository crates.
 - `crates/oxmux`: Headless reusable Rust core boundary. It currently exposes a
-  small identity facade plus placeholder domain boundaries for future provider,
-  routing, protocol, configuration, management, usage, streaming, and error
-  ownership.
+  small identity facade plus domain boundaries for provider execution, routing,
+  protocol, configuration, management, usage, streaming, and error ownership.
+  It is the home for subscription-aware routing, request rewrite primitives,
+  model aliases, reasoning/thinking compatibility behavior, and local proxy
+  contracts that must work without a desktop shell.
 - `crates/oxidemux`: App and integration shell. It owns the binary entrypoint
   and will own future GPUI, tray/background lifecycle, updater, packaging,
-  platform credential storage, and IDE adapter work.
+  platform credential storage, subscription onboarding/repair UI, and IDE
+  adapter work.
+- `docs/vision.md`: Canonical product intent for humans and agents.
+- `docs/architecture.md`: Crate boundary and architecture guardrails.
 - `rust-toolchain.toml`: Pinned Rust 1.95.0 toolchain.
 - `LICENSE-MIT` and `LICENSE-APACHE`: Dual-license files.
 - `.github/workflows/ci.yml`: Multi-platform verification workflow.
@@ -147,6 +159,13 @@ foundation, we intend to deliver a responsive and resource-efficient interface
 across Linux, macOS, and Windows. Platform support will be validated and
 refined during the UI implementation phase.
 
+The shared `oxmux` core owns behavior that must be consistent across platforms:
+protocol compatibility, request rewriting, model aliasing, reasoning/thinking
+options, subscription-aware routing, provider/account state, usage/quota
+summaries, and structured failures. The `oxidemux` app shell adapts that core to
+GPUI, tray/menu integration, notifications, platform credential storage,
+packaging, updates, and OS-specific lifecycle UX.
+
 ## Inspiration and Attribution
 
 OxideMux is an independent, from-scratch implementation. Its proxy/gateway
@@ -158,8 +177,10 @@ and management endpoints. Its desktop concepts are informed by
 proxy lifecycle controls, tray/background operation, themes, and updates.
 
 The original product idea also drew inspiration from
-[VibeProxy](https://github.com/automazeio/vibeproxy). No code or wording has
-been copied from any inspiration project.
+[VibeProxy](https://github.com/automazeio/vibeproxy), especially its
+subscription-first local proxy UX, auth/session handling, model aliases,
+provider-specific routing, and thinking/reasoning request compatibility layer.
+No code or wording has been copied from any inspiration project.
 
 ## License
 

--- a/crates/oxmux/src/errors.rs
+++ b/crates/oxmux/src/errors.rs
@@ -1,6 +1,8 @@
 use core::fmt;
 
-use crate::{ProtocolFamily, ProtocolTranslationDirection, ProviderExecutionFailure};
+use crate::{
+    ProtocolFamily, ProtocolTranslationDirection, ProviderExecutionFailure, RoutingFailure,
+};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum CoreError {
@@ -51,6 +53,9 @@ pub enum CoreError {
         source_family: ProtocolFamily,
         target_family: ProtocolFamily,
         message: String,
+    },
+    Routing {
+        failure: RoutingFailure,
     },
 }
 
@@ -119,6 +124,9 @@ impl fmt::Display for CoreError {
                 formatter,
                 "protocol {direction:?} translation from {source_family:?} to {target_family:?} is deferred: {message}"
             ),
+            Self::Routing { failure } => {
+                write!(formatter, "routing failed: {}", failure.message())
+            }
         }
     }
 }

--- a/crates/oxmux/src/local_proxy_runtime.rs
+++ b/crates/oxmux/src/local_proxy_runtime.rs
@@ -281,7 +281,7 @@ fn serve_health_requests(
 
 fn handle_connection(mut stream: TcpStream) -> Result<(), CoreError> {
     stream
-        .set_read_timeout(Some(Duration::from_millis(100)))
+        .set_read_timeout(Some(Duration::from_secs(1)))
         .map_err(|error| CoreError::LocalRuntimeHealthServing {
             message: format!("failed to set request read timeout: {error}"),
         })?;

--- a/crates/oxmux/src/local_proxy_runtime.rs
+++ b/crates/oxmux/src/local_proxy_runtime.rs
@@ -346,7 +346,7 @@ fn write_response(stream: &mut TcpStream, status: &str, body: &str) -> Result<()
 
 #[cfg(test)]
 mod tests {
-    use std::io::Write;
+    use std::io::{ErrorKind, Write};
     use std::net::{Shutdown, TcpListener, TcpStream};
     use std::thread;
 
@@ -367,8 +367,15 @@ mod tests {
         });
 
         let mut stream = TcpStream::connect(socket_addr)?;
-        stream.write_all(&vec![b'a'; MAX_LOCAL_HEALTH_REQUEST_BYTES + 512])?;
-        stream.shutdown(Shutdown::Write)?;
+        match stream.write_all(&vec![b'a'; MAX_LOCAL_HEALTH_REQUEST_BYTES + 512]) {
+            Ok(()) => stream.shutdown(Shutdown::Write)?,
+            Err(error)
+                if matches!(
+                    error.kind(),
+                    ErrorKind::BrokenPipe | ErrorKind::ConnectionReset | ErrorKind::NotConnected
+                ) => {}
+            Err(error) => return Err(error.into()),
+        }
 
         let request_line = match reader.join() {
             Ok(result) => result?,

--- a/crates/oxmux/src/oxmux.rs
+++ b/crates/oxmux/src/oxmux.rs
@@ -34,6 +34,12 @@ pub use provider::{
     ProviderExecutionOutcome, ProviderExecutionRequest, ProviderExecutionResult, ProviderExecutor,
     ProviderSummary,
 };
+pub use routing::{
+    FallbackBehavior, ModelAlias, ModelRoute, RoutingAvailabilitySnapshot,
+    RoutingAvailabilityState, RoutingBoundary, RoutingCandidate, RoutingDecisionMode,
+    RoutingFailure, RoutingPolicy, RoutingSelectionRequest, RoutingSelectionResult,
+    RoutingSkipReason, RoutingTarget, RoutingTargetAvailability, SkippedRoutingCandidate,
+};
 pub use usage::{MeteredValue, QuotaState, QuotaSummary, UsageSummary};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/oxmux/src/routing.rs
+++ b/crates/oxmux/src/routing.rs
@@ -536,7 +536,9 @@ impl RoutingSkipReason {
                 format!("degraded routing is not allowed: {reason}")
             }
             Self::DegradedDeferred { reason } => {
-                format!("degraded candidate deferred while healthy fallback is available: {reason}")
+                format!(
+                    "degraded candidate deferred while checking for a healthier route: {reason}"
+                )
             }
         }
     }

--- a/crates/oxmux/src/routing.rs
+++ b/crates/oxmux/src/routing.rs
@@ -736,6 +736,11 @@ fn evaluate_candidates(
     }
 
     if allow_degraded && let Some((target, reason, decision_mode)) = deferred_degraded.first() {
+        let skipped = skipped
+            .into_iter()
+            .filter(|candidate| candidate.target != *target)
+            .collect();
+
         return Ok(selection(
             requested_model,
             resolved_model,

--- a/crates/oxmux/src/routing.rs
+++ b/crates/oxmux/src/routing.rs
@@ -1,2 +1,786 @@
+use crate::CoreError;
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct RoutingBoundary;
+
+impl RoutingBoundary {
+    pub fn select(
+        policy: &RoutingPolicy,
+        request: &RoutingSelectionRequest,
+        availability: &RoutingAvailabilitySnapshot,
+    ) -> Result<RoutingSelectionResult, CoreError> {
+        policy.select(request, availability)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoutingPolicy {
+    pub model_aliases: Vec<ModelAlias>,
+    pub routes: Vec<ModelRoute>,
+    pub fallback: FallbackBehavior,
+    pub default_target: Option<RoutingTarget>,
+}
+
+impl RoutingPolicy {
+    pub fn new(routes: Vec<ModelRoute>) -> Self {
+        Self {
+            model_aliases: Vec::new(),
+            routes,
+            fallback: FallbackBehavior::default(),
+            default_target: None,
+        }
+    }
+
+    pub fn with_model_alias(mut self, alias: ModelAlias) -> Self {
+        self.model_aliases.push(alias);
+        self
+    }
+
+    pub fn with_fallback(mut self, fallback: FallbackBehavior) -> Self {
+        self.fallback = fallback;
+        self
+    }
+
+    pub fn with_default_target(mut self, target: RoutingTarget) -> Self {
+        self.default_target = Some(target);
+        self
+    }
+
+    pub fn validate(&self) -> Result<(), CoreError> {
+        if let Some(target) = &self.default_target {
+            target.validate("default_target")?;
+        }
+
+        for alias in &self.model_aliases {
+            alias.validate()?;
+        }
+
+        for (index, alias) in self.model_aliases.iter().enumerate() {
+            if self
+                .model_aliases
+                .iter()
+                .skip(index + 1)
+                .any(|candidate| candidate.requested_model == alias.requested_model)
+            {
+                return Err(invalid_policy(
+                    "model_aliases",
+                    format!(
+                        "model alias {} is defined more than once",
+                        alias.requested_model
+                    ),
+                ));
+            }
+        }
+
+        for route in &self.routes {
+            route.validate()?;
+        }
+
+        for (index, route) in self.routes.iter().enumerate() {
+            if self
+                .routes
+                .iter()
+                .skip(index + 1)
+                .any(|candidate| candidate.resolved_model == route.resolved_model)
+            {
+                return Err(invalid_policy(
+                    "routes",
+                    format!(
+                        "route for model {} is defined more than once",
+                        route.resolved_model
+                    ),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn select(
+        &self,
+        request: &RoutingSelectionRequest,
+        availability: &RoutingAvailabilitySnapshot,
+    ) -> Result<RoutingSelectionResult, CoreError> {
+        self.validate()?;
+        request.validate()?;
+        availability.validate()?;
+
+        let requested_model = request.requested_model.clone();
+        let resolved_model = self.resolve_model(&requested_model);
+
+        if let Some(target) = request
+            .explicit_target
+            .as_ref()
+            .or(self.default_target.as_ref())
+        {
+            return self.select_explicit_target(
+                target,
+                &requested_model,
+                &resolved_model,
+                request
+                    .allow_degraded
+                    .unwrap_or(self.fallback.allow_degraded),
+                availability,
+            );
+        }
+
+        let Some(route) = self
+            .routes
+            .iter()
+            .find(|route| route.resolved_model == resolved_model)
+        else {
+            return Err(CoreError::Routing {
+                failure: RoutingFailure::NoRoute {
+                    requested_model,
+                    resolved_model,
+                },
+            });
+        };
+
+        if route.candidates.is_empty() {
+            return Err(CoreError::Routing {
+                failure: RoutingFailure::NoRoute {
+                    requested_model,
+                    resolved_model,
+                },
+            });
+        }
+
+        let fallback_enabled = request
+            .fallback_enabled
+            .unwrap_or(self.fallback.fallback_enabled);
+        let allow_degraded = request
+            .allow_degraded
+            .unwrap_or(self.fallback.allow_degraded);
+
+        evaluate_candidates(
+            &requested_model,
+            &resolved_model,
+            &route.candidates,
+            fallback_enabled,
+            allow_degraded,
+            availability,
+        )
+    }
+
+    fn resolve_model(&self, requested_model: &str) -> String {
+        self.model_aliases
+            .iter()
+            .find(|alias| alias.requested_model == requested_model)
+            .map(|alias| alias.resolved_model.clone())
+            .unwrap_or_else(|| requested_model.to_string())
+    }
+
+    fn select_explicit_target(
+        &self,
+        target: &RoutingTarget,
+        requested_model: &str,
+        resolved_model: &str,
+        allow_degraded: bool,
+        availability: &RoutingAvailabilitySnapshot,
+    ) -> Result<RoutingSelectionResult, CoreError> {
+        let Some(state) = availability.state_for(target) else {
+            return Err(CoreError::Routing {
+                failure: RoutingFailure::MissingExplicitTarget {
+                    target: target.clone(),
+                },
+            });
+        };
+
+        match state {
+            RoutingAvailabilityState::Available => Ok(selection(
+                requested_model,
+                resolved_model,
+                target,
+                state,
+                RoutingDecisionMode::ExplicitTarget,
+                Vec::new(),
+            )),
+            RoutingAvailabilityState::Degraded { .. } if allow_degraded => Ok(selection(
+                requested_model,
+                resolved_model,
+                target,
+                state,
+                RoutingDecisionMode::ExplicitTarget,
+                Vec::new(),
+            )),
+            RoutingAvailabilityState::Degraded { reason } => Err(CoreError::Routing {
+                failure: RoutingFailure::DegradedOnlyCandidates {
+                    requested_model: requested_model.to_string(),
+                    resolved_model: resolved_model.to_string(),
+                    skipped: vec![SkippedRoutingCandidate {
+                        target: target.clone(),
+                        reason: RoutingSkipReason::DegradedDisallowed {
+                            reason: reason.clone(),
+                        },
+                    }],
+                },
+            }),
+            RoutingAvailabilityState::Exhausted { reason } => Err(CoreError::Routing {
+                failure: RoutingFailure::ExhaustedCandidates {
+                    requested_model: requested_model.to_string(),
+                    resolved_model: resolved_model.to_string(),
+                    skipped: vec![SkippedRoutingCandidate {
+                        target: target.clone(),
+                        reason: RoutingSkipReason::Exhausted {
+                            reason: reason.clone(),
+                        },
+                    }],
+                },
+            }),
+            RoutingAvailabilityState::Unavailable { reason } => Err(CoreError::Routing {
+                failure: RoutingFailure::NoAvailableCandidates {
+                    requested_model: requested_model.to_string(),
+                    resolved_model: resolved_model.to_string(),
+                    skipped: vec![SkippedRoutingCandidate {
+                        target: target.clone(),
+                        reason: RoutingSkipReason::Unavailable {
+                            reason: reason.clone(),
+                        },
+                    }],
+                },
+            }),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ModelAlias {
+    pub requested_model: String,
+    pub resolved_model: String,
+}
+
+impl ModelAlias {
+    pub fn new(requested_model: impl Into<String>, resolved_model: impl Into<String>) -> Self {
+        Self {
+            requested_model: requested_model.into(),
+            resolved_model: resolved_model.into(),
+        }
+    }
+
+    fn validate(&self) -> Result<(), CoreError> {
+        validate_required_text("model_aliases.requested_model", &self.requested_model)?;
+        validate_required_text("model_aliases.resolved_model", &self.resolved_model)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ModelRoute {
+    pub resolved_model: String,
+    pub candidates: Vec<RoutingCandidate>,
+}
+
+impl ModelRoute {
+    pub fn new(resolved_model: impl Into<String>, candidates: Vec<RoutingCandidate>) -> Self {
+        Self {
+            resolved_model: resolved_model.into(),
+            candidates,
+        }
+    }
+
+    fn validate(&self) -> Result<(), CoreError> {
+        validate_required_text("routes.resolved_model", &self.resolved_model)?;
+
+        for candidate in &self.candidates {
+            candidate.validate()?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoutingCandidate {
+    pub target: RoutingTarget,
+}
+
+impl RoutingCandidate {
+    pub fn new(target: RoutingTarget) -> Self {
+        Self { target }
+    }
+
+    fn validate(&self) -> Result<(), CoreError> {
+        self.target.validate("routes.candidates.target")
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoutingTarget {
+    pub provider_id: String,
+    pub account_id: Option<String>,
+}
+
+impl RoutingTarget {
+    pub fn provider(provider_id: impl Into<String>) -> Self {
+        Self {
+            provider_id: provider_id.into(),
+            account_id: None,
+        }
+    }
+
+    pub fn provider_account(provider_id: impl Into<String>, account_id: impl Into<String>) -> Self {
+        Self {
+            provider_id: provider_id.into(),
+            account_id: Some(account_id.into()),
+        }
+    }
+
+    fn validate(&self, field: &'static str) -> Result<(), CoreError> {
+        validate_required_text(field, &self.provider_id)?;
+
+        if let Some(account_id) = &self.account_id {
+            validate_required_text(field, account_id)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FallbackBehavior {
+    pub fallback_enabled: bool,
+    pub allow_degraded: bool,
+}
+
+impl FallbackBehavior {
+    pub const fn new(fallback_enabled: bool, allow_degraded: bool) -> Self {
+        Self {
+            fallback_enabled,
+            allow_degraded,
+        }
+    }
+
+    pub const fn disabled() -> Self {
+        Self::new(false, false)
+    }
+}
+
+impl Default for FallbackBehavior {
+    fn default() -> Self {
+        Self::new(true, false)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoutingAvailabilitySnapshot {
+    pub targets: Vec<RoutingTargetAvailability>,
+}
+
+impl RoutingAvailabilitySnapshot {
+    pub fn new(targets: Vec<RoutingTargetAvailability>) -> Self {
+        Self { targets }
+    }
+
+    pub fn state_for(&self, target: &RoutingTarget) -> Option<&RoutingAvailabilityState> {
+        self.targets
+            .iter()
+            .find(|availability| availability.target == *target)
+            .map(|availability| &availability.state)
+    }
+
+    pub fn validate(&self) -> Result<(), CoreError> {
+        for availability in &self.targets {
+            availability.validate()?;
+        }
+
+        for (index, availability) in self.targets.iter().enumerate() {
+            if self
+                .targets
+                .iter()
+                .skip(index + 1)
+                .any(|candidate| candidate.target == availability.target)
+            {
+                return Err(invalid_policy(
+                    "availability.targets",
+                    format!(
+                        "availability for provider {} is defined more than once",
+                        availability.target.provider_id
+                    ),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoutingTargetAvailability {
+    pub target: RoutingTarget,
+    pub state: RoutingAvailabilityState,
+}
+
+impl RoutingTargetAvailability {
+    pub fn new(target: RoutingTarget, state: RoutingAvailabilityState) -> Self {
+        Self { target, state }
+    }
+
+    fn validate(&self) -> Result<(), CoreError> {
+        self.target.validate("availability.targets.target")?;
+        self.state.validate()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RoutingAvailabilityState {
+    Available,
+    Unavailable { reason: String },
+    Exhausted { reason: String },
+    Degraded { reason: String },
+}
+
+impl RoutingAvailabilityState {
+    fn validate(&self) -> Result<(), CoreError> {
+        match self {
+            Self::Available => Ok(()),
+            Self::Unavailable { reason } => validate_required_text("availability.reason", reason),
+            Self::Exhausted { reason } => validate_required_text("availability.reason", reason),
+            Self::Degraded { reason } => validate_required_text("availability.reason", reason),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoutingSelectionRequest {
+    pub requested_model: String,
+    pub explicit_target: Option<RoutingTarget>,
+    pub fallback_enabled: Option<bool>,
+    pub allow_degraded: Option<bool>,
+}
+
+impl RoutingSelectionRequest {
+    pub fn new(requested_model: impl Into<String>) -> Self {
+        Self {
+            requested_model: requested_model.into(),
+            explicit_target: None,
+            fallback_enabled: None,
+            allow_degraded: None,
+        }
+    }
+
+    pub fn with_explicit_target(mut self, target: RoutingTarget) -> Self {
+        self.explicit_target = Some(target);
+        self
+    }
+
+    pub fn with_fallback_enabled(mut self, fallback_enabled: bool) -> Self {
+        self.fallback_enabled = Some(fallback_enabled);
+        self
+    }
+
+    pub fn with_degraded_allowed(mut self, allow_degraded: bool) -> Self {
+        self.allow_degraded = Some(allow_degraded);
+        self
+    }
+
+    fn validate(&self) -> Result<(), CoreError> {
+        validate_required_text("requested_model", &self.requested_model)?;
+
+        if let Some(target) = &self.explicit_target {
+            target.validate("explicit_target")?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RoutingSelectionResult {
+    pub requested_model: String,
+    pub resolved_model: String,
+    pub selected_target: RoutingTarget,
+    pub selected_state: RoutingAvailabilityState,
+    pub decision_mode: RoutingDecisionMode,
+    pub skipped_candidates: Vec<SkippedRoutingCandidate>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum RoutingDecisionMode {
+    ExplicitTarget,
+    Priority,
+    Fallback,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SkippedRoutingCandidate {
+    pub target: RoutingTarget,
+    pub reason: RoutingSkipReason,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RoutingSkipReason {
+    MissingAvailability,
+    Unavailable { reason: String },
+    Exhausted { reason: String },
+    DegradedDisallowed { reason: String },
+    DegradedDeferred { reason: String },
+}
+
+impl RoutingSkipReason {
+    pub fn message(&self) -> String {
+        match self {
+            Self::MissingAvailability => "availability was not supplied".to_string(),
+            Self::Unavailable { reason } => format!("unavailable: {reason}"),
+            Self::Exhausted { reason } => format!("exhausted: {reason}"),
+            Self::DegradedDisallowed { reason } => {
+                format!("degraded routing is not allowed: {reason}")
+            }
+            Self::DegradedDeferred { reason } => {
+                format!("degraded candidate deferred while healthy fallback is available: {reason}")
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum RoutingFailure {
+    InvalidPolicy {
+        field: &'static str,
+        message: String,
+    },
+    InvalidRequest {
+        field: &'static str,
+        message: String,
+    },
+    NoRoute {
+        requested_model: String,
+        resolved_model: String,
+    },
+    MissingExplicitTarget {
+        target: RoutingTarget,
+    },
+    FallbackDisabled {
+        target: RoutingTarget,
+        reason: RoutingSkipReason,
+    },
+    ExhaustedCandidates {
+        requested_model: String,
+        resolved_model: String,
+        skipped: Vec<SkippedRoutingCandidate>,
+    },
+    DegradedOnlyCandidates {
+        requested_model: String,
+        resolved_model: String,
+        skipped: Vec<SkippedRoutingCandidate>,
+    },
+    NoAvailableCandidates {
+        requested_model: String,
+        resolved_model: String,
+        skipped: Vec<SkippedRoutingCandidate>,
+    },
+}
+
+impl RoutingFailure {
+    pub fn message(&self) -> String {
+        match self {
+            Self::InvalidPolicy { field, message } => {
+                format!("routing policy field {field} is invalid: {message}")
+            }
+            Self::InvalidRequest { field, message } => {
+                format!("routing request field {field} is invalid: {message}")
+            }
+            Self::NoRoute {
+                requested_model,
+                resolved_model,
+            } => format!(
+                "no route is configured for requested model {requested_model} resolved as {resolved_model}"
+            ),
+            Self::MissingExplicitTarget { target } => {
+                format!(
+                    "explicit target {} is missing from availability",
+                    target.label()
+                )
+            }
+            Self::FallbackDisabled { target, reason } => format!(
+                "fallback is disabled after target {} failed selection: {}",
+                target.label(),
+                reason.message()
+            ),
+            Self::ExhaustedCandidates {
+                resolved_model,
+                skipped,
+                ..
+            } => format!(
+                "all routing candidates for model {resolved_model} are exhausted ({} skipped)",
+                skipped.len()
+            ),
+            Self::DegradedOnlyCandidates {
+                resolved_model,
+                skipped,
+                ..
+            } => format!(
+                "only degraded routing candidates remain for model {resolved_model} ({} skipped)",
+                skipped.len()
+            ),
+            Self::NoAvailableCandidates {
+                resolved_model,
+                skipped,
+                ..
+            } => format!(
+                "no available routing candidates remain for model {resolved_model} ({} skipped)",
+                skipped.len()
+            ),
+        }
+    }
+}
+
+impl RoutingTarget {
+    fn label(&self) -> String {
+        match &self.account_id {
+            Some(account_id) => format!("{}/{}", self.provider_id, account_id),
+            None => self.provider_id.clone(),
+        }
+    }
+}
+
+fn evaluate_candidates(
+    requested_model: &str,
+    resolved_model: &str,
+    candidates: &[RoutingCandidate],
+    fallback_enabled: bool,
+    allow_degraded: bool,
+    availability: &RoutingAvailabilitySnapshot,
+) -> Result<RoutingSelectionResult, CoreError> {
+    let mut skipped = Vec::new();
+    let mut deferred_degraded = Vec::new();
+
+    for (index, candidate) in candidates.iter().enumerate() {
+        let target = &candidate.target;
+        let decision_mode = if index == 0 {
+            RoutingDecisionMode::Priority
+        } else {
+            RoutingDecisionMode::Fallback
+        };
+        let skip_reason = match availability.state_for(target) {
+            Some(RoutingAvailabilityState::Available) => {
+                return Ok(selection(
+                    requested_model,
+                    resolved_model,
+                    target,
+                    &RoutingAvailabilityState::Available,
+                    decision_mode,
+                    skipped,
+                ));
+            }
+            Some(RoutingAvailabilityState::Degraded { reason }) => {
+                let skipped_candidate = SkippedRoutingCandidate {
+                    target: target.clone(),
+                    reason: RoutingSkipReason::DegradedDeferred {
+                        reason: reason.clone(),
+                    },
+                };
+                deferred_degraded.push((target.clone(), reason.clone(), decision_mode));
+                skipped_candidate
+            }
+            Some(RoutingAvailabilityState::Unavailable { reason }) => SkippedRoutingCandidate {
+                target: target.clone(),
+                reason: RoutingSkipReason::Unavailable {
+                    reason: reason.clone(),
+                },
+            },
+            Some(RoutingAvailabilityState::Exhausted { reason }) => SkippedRoutingCandidate {
+                target: target.clone(),
+                reason: RoutingSkipReason::Exhausted {
+                    reason: reason.clone(),
+                },
+            },
+            None => SkippedRoutingCandidate {
+                target: target.clone(),
+                reason: RoutingSkipReason::MissingAvailability,
+            },
+        };
+
+        if !fallback_enabled {
+            return Err(CoreError::Routing {
+                failure: RoutingFailure::FallbackDisabled {
+                    target: target.clone(),
+                    reason: skip_reason.reason,
+                },
+            });
+        }
+
+        skipped.push(skip_reason);
+    }
+
+    if allow_degraded && let Some((target, reason, decision_mode)) = deferred_degraded.first() {
+        return Ok(selection(
+            requested_model,
+            resolved_model,
+            target,
+            &RoutingAvailabilityState::Degraded {
+                reason: reason.clone(),
+            },
+            *decision_mode,
+            skipped,
+        ));
+    }
+
+    if skipped.iter().any(|candidate| {
+        matches!(
+            candidate.reason,
+            RoutingSkipReason::DegradedDeferred { .. }
+                | RoutingSkipReason::DegradedDisallowed { .. }
+        )
+    }) {
+        return Err(CoreError::Routing {
+            failure: RoutingFailure::DegradedOnlyCandidates {
+                requested_model: requested_model.to_string(),
+                resolved_model: resolved_model.to_string(),
+                skipped,
+            },
+        });
+    }
+
+    if skipped
+        .iter()
+        .all(|candidate| matches!(candidate.reason, RoutingSkipReason::Exhausted { .. }))
+    {
+        return Err(CoreError::Routing {
+            failure: RoutingFailure::ExhaustedCandidates {
+                requested_model: requested_model.to_string(),
+                resolved_model: resolved_model.to_string(),
+                skipped,
+            },
+        });
+    }
+
+    Err(CoreError::Routing {
+        failure: RoutingFailure::NoAvailableCandidates {
+            requested_model: requested_model.to_string(),
+            resolved_model: resolved_model.to_string(),
+            skipped,
+        },
+    })
+}
+
+fn selection(
+    requested_model: &str,
+    resolved_model: &str,
+    target: &RoutingTarget,
+    state: &RoutingAvailabilityState,
+    decision_mode: RoutingDecisionMode,
+    skipped_candidates: Vec<SkippedRoutingCandidate>,
+) -> RoutingSelectionResult {
+    RoutingSelectionResult {
+        requested_model: requested_model.to_string(),
+        resolved_model: resolved_model.to_string(),
+        selected_target: target.clone(),
+        selected_state: state.clone(),
+        decision_mode,
+        skipped_candidates,
+    }
+}
+
+fn validate_required_text(field: &'static str, value: &str) -> Result<(), CoreError> {
+    if value.trim().is_empty() {
+        return Err(invalid_policy(field, format!("{field} must not be empty")));
+    }
+
+    Ok(())
+}
+
+fn invalid_policy(field: &'static str, message: String) -> CoreError {
+    CoreError::Routing {
+        failure: RoutingFailure::InvalidPolicy { field, message },
+    }
+}

--- a/crates/oxmux/src/routing.rs
+++ b/crates/oxmux/src/routing.rs
@@ -334,6 +334,16 @@ impl RoutingTarget {
 
         Ok(())
     }
+
+    fn validate_request(&self, field: &'static str) -> Result<(), CoreError> {
+        validate_required_request_text(field, &self.provider_id)?;
+
+        if let Some(account_id) = &self.account_id {
+            validate_required_request_text(field, account_id)?;
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -474,10 +484,10 @@ impl RoutingSelectionRequest {
     }
 
     fn validate(&self) -> Result<(), CoreError> {
-        validate_required_text("requested_model", &self.requested_model)?;
+        validate_required_request_text("requested_model", &self.requested_model)?;
 
         if let Some(target) = &self.explicit_target {
-            target.validate("explicit_target")?;
+            target.validate_request("explicit_target")?;
         }
 
         Ok(())
@@ -663,13 +673,36 @@ fn evaluate_candidates(
                 ));
             }
             Some(RoutingAvailabilityState::Degraded { reason }) => {
+                if allow_degraded && !fallback_enabled {
+                    return Ok(selection(
+                        requested_model,
+                        resolved_model,
+                        target,
+                        &RoutingAvailabilityState::Degraded {
+                            reason: reason.clone(),
+                        },
+                        decision_mode,
+                        skipped,
+                    ));
+                }
+
                 let skipped_candidate = SkippedRoutingCandidate {
                     target: target.clone(),
-                    reason: RoutingSkipReason::DegradedDeferred {
-                        reason: reason.clone(),
+                    reason: if allow_degraded {
+                        RoutingSkipReason::DegradedDeferred {
+                            reason: reason.clone(),
+                        }
+                    } else {
+                        RoutingSkipReason::DegradedDisallowed {
+                            reason: reason.clone(),
+                        }
                     },
                 };
-                deferred_degraded.push((target.clone(), reason.clone(), decision_mode));
+
+                if allow_degraded {
+                    deferred_degraded.push((target.clone(), reason.clone(), decision_mode));
+                }
+
                 skipped_candidate
             }
             Some(RoutingAvailabilityState::Unavailable { reason }) => SkippedRoutingCandidate {
@@ -715,7 +748,7 @@ fn evaluate_candidates(
         ));
     }
 
-    if skipped.iter().any(|candidate| {
+    if skipped.iter().all(|candidate| {
         matches!(
             candidate.reason,
             RoutingSkipReason::DegradedDeferred { .. }
@@ -777,6 +810,20 @@ fn validate_required_text(field: &'static str, value: &str) -> Result<(), CoreEr
     }
 
     Ok(())
+}
+
+fn validate_required_request_text(field: &'static str, value: &str) -> Result<(), CoreError> {
+    if value.trim().is_empty() {
+        return Err(invalid_request(field, format!("{field} must not be empty")));
+    }
+
+    Ok(())
+}
+
+fn invalid_request(field: &'static str, message: String) -> CoreError {
+    CoreError::Routing {
+        failure: RoutingFailure::InvalidRequest { field, message },
+    }
 }
 
 fn invalid_policy(field: &'static str, message: String) -> CoreError {

--- a/crates/oxmux/tests/routing_policy.rs
+++ b/crates/oxmux/tests/routing_policy.rs
@@ -1,0 +1,279 @@
+use oxmux::{
+    CoreError, FallbackBehavior, ModelAlias, ModelRoute, RoutingAvailabilitySnapshot,
+    RoutingAvailabilityState, RoutingBoundary, RoutingCandidate, RoutingDecisionMode,
+    RoutingFailure, RoutingPolicy, RoutingSelectionRequest, RoutingSkipReason, RoutingTarget,
+    RoutingTargetAvailability,
+};
+
+#[test]
+fn model_alias_resolution_preserves_requested_and_resolved_models() -> Result<(), CoreError> {
+    let openai = RoutingTarget::provider_account("openai", "primary");
+    let policy = RoutingPolicy::new(vec![ModelRoute::new(
+        "gpt-4o",
+        vec![RoutingCandidate::new(openai.clone())],
+    )])
+    .with_model_alias(ModelAlias::new("smart", "gpt-4o"));
+    let availability = available_snapshot(vec![openai.clone()]);
+
+    let selection = RoutingBoundary::select(
+        &policy,
+        &RoutingSelectionRequest::new("smart"),
+        &availability,
+    )?;
+
+    assert_eq!(selection.requested_model, "smart");
+    assert_eq!(selection.resolved_model, "gpt-4o");
+    assert_eq!(selection.selected_target, openai);
+    assert_eq!(selection.decision_mode, RoutingDecisionMode::Priority);
+    Ok(())
+}
+
+#[test]
+fn priority_order_selects_first_available_candidate() -> Result<(), CoreError> {
+    let primary = RoutingTarget::provider_account("openai", "primary");
+    let secondary = RoutingTarget::provider_account("anthropic", "fallback");
+    let policy = policy_with_candidates(vec![primary.clone(), secondary]);
+    let availability = available_snapshot(vec![primary.clone()]);
+
+    let selection = policy.select(&RoutingSelectionRequest::new("gpt-4o"), &availability)?;
+
+    assert_eq!(selection.selected_target, primary);
+    assert_eq!(selection.decision_mode, RoutingDecisionMode::Priority);
+    assert!(selection.skipped_candidates.is_empty());
+    Ok(())
+}
+
+#[test]
+fn fallback_enabled_skips_unavailable_candidate() -> Result<(), CoreError> {
+    let primary = RoutingTarget::provider_account("openai", "primary");
+    let secondary = RoutingTarget::provider_account("anthropic", "fallback");
+    let policy = policy_with_candidates(vec![primary.clone(), secondary.clone()]);
+    let availability = RoutingAvailabilitySnapshot::new(vec![
+        RoutingTargetAvailability::new(
+            primary.clone(),
+            RoutingAvailabilityState::Unavailable {
+                reason: "maintenance".to_string(),
+            },
+        ),
+        RoutingTargetAvailability::new(secondary.clone(), RoutingAvailabilityState::Available),
+    ]);
+
+    let selection = policy.select(&RoutingSelectionRequest::new("gpt-4o"), &availability)?;
+
+    assert_eq!(selection.selected_target, secondary);
+    assert_eq!(selection.decision_mode, RoutingDecisionMode::Fallback);
+    assert_eq!(selection.skipped_candidates.len(), 1);
+    assert!(matches!(
+        selection.skipped_candidates[0].reason,
+        RoutingSkipReason::Unavailable { .. }
+    ));
+    Ok(())
+}
+
+#[test]
+fn fallback_disabled_returns_structured_failure() {
+    let primary = RoutingTarget::provider_account("openai", "primary");
+    let secondary = RoutingTarget::provider_account("anthropic", "fallback");
+    let policy = policy_with_candidates(vec![primary.clone(), secondary.clone()]);
+    let availability = RoutingAvailabilitySnapshot::new(vec![
+        RoutingTargetAvailability::new(
+            primary.clone(),
+            RoutingAvailabilityState::Exhausted {
+                reason: "quota exhausted".to_string(),
+            },
+        ),
+        RoutingTargetAvailability::new(secondary, RoutingAvailabilityState::Available),
+    ]);
+    let request = RoutingSelectionRequest::new("gpt-4o").with_fallback_enabled(false);
+
+    let error = policy.select(&request, &availability);
+
+    assert!(matches!(
+        error,
+        Err(CoreError::Routing {
+            failure: RoutingFailure::FallbackDisabled { target, reason }
+        }) if target == primary && matches!(reason, RoutingSkipReason::Exhausted { .. })
+    ));
+}
+
+#[test]
+fn explicit_account_target_wins_over_priority_candidates() -> Result<(), CoreError> {
+    let primary = RoutingTarget::provider_account("openai", "primary");
+    let explicit = RoutingTarget::provider_account("anthropic", "team");
+    let policy = policy_with_candidates(vec![primary, explicit.clone()]);
+    let availability = available_snapshot(vec![explicit.clone()]);
+    let request = RoutingSelectionRequest::new("gpt-4o").with_explicit_target(explicit.clone());
+
+    let selection = policy.select(&request, &availability)?;
+
+    assert_eq!(selection.selected_target, explicit);
+    assert_eq!(selection.decision_mode, RoutingDecisionMode::ExplicitTarget);
+    Ok(())
+}
+
+#[test]
+fn missing_explicit_target_fails_without_fallback() {
+    let primary = RoutingTarget::provider_account("openai", "primary");
+    let explicit = RoutingTarget::provider_account("anthropic", "team");
+    let policy = policy_with_candidates(vec![primary.clone()]);
+    let availability = available_snapshot(vec![primary]);
+    let request = RoutingSelectionRequest::new("gpt-4o").with_explicit_target(explicit.clone());
+
+    let error = policy.select(&request, &availability);
+
+    assert!(matches!(
+        error,
+        Err(CoreError::Routing {
+            failure: RoutingFailure::MissingExplicitTarget { target }
+        }) if target == explicit
+    ));
+}
+
+#[test]
+fn exhausted_candidates_fail_structurally() {
+    let primary = RoutingTarget::provider_account("openai", "primary");
+    let fallback = RoutingTarget::provider_account("anthropic", "fallback");
+    let policy = policy_with_candidates(vec![primary.clone(), fallback.clone()]);
+    let availability = RoutingAvailabilitySnapshot::new(vec![
+        RoutingTargetAvailability::new(
+            primary,
+            RoutingAvailabilityState::Exhausted {
+                reason: "daily quota".to_string(),
+            },
+        ),
+        RoutingTargetAvailability::new(
+            fallback,
+            RoutingAvailabilityState::Exhausted {
+                reason: "monthly quota".to_string(),
+            },
+        ),
+    ]);
+
+    let error = policy.select(&RoutingSelectionRequest::new("gpt-4o"), &availability);
+
+    assert!(matches!(
+        error,
+        Err(CoreError::Routing {
+            failure: RoutingFailure::ExhaustedCandidates { skipped, .. }
+        }) if skipped.len() == 2
+    ));
+}
+
+#[test]
+fn degraded_candidate_is_selected_only_when_allowed() -> Result<(), CoreError> {
+    let degraded = RoutingTarget::provider_account("openai", "primary");
+    let policy = policy_with_candidates(vec![degraded.clone()]);
+    let availability = RoutingAvailabilitySnapshot::new(vec![RoutingTargetAvailability::new(
+        degraded.clone(),
+        RoutingAvailabilityState::Degraded {
+            reason: "stale quota".to_string(),
+        },
+    )]);
+
+    let disallowed = policy.select(&RoutingSelectionRequest::new("gpt-4o"), &availability);
+    assert!(matches!(
+        disallowed,
+        Err(CoreError::Routing {
+            failure: RoutingFailure::DegradedOnlyCandidates { .. }
+        })
+    ));
+
+    let allowed = policy.select(
+        &RoutingSelectionRequest::new("gpt-4o").with_degraded_allowed(true),
+        &availability,
+    )?;
+    assert_eq!(allowed.selected_target, degraded);
+    assert!(matches!(
+        allowed.selected_state,
+        RoutingAvailabilityState::Degraded { .. }
+    ));
+    Ok(())
+}
+
+#[test]
+fn healthy_fallback_wins_over_degraded_higher_priority_candidate() -> Result<(), CoreError> {
+    let degraded = RoutingTarget::provider_account("openai", "primary");
+    let healthy = RoutingTarget::provider_account("anthropic", "fallback");
+    let policy = policy_with_candidates(vec![degraded.clone(), healthy.clone()]);
+    let availability = RoutingAvailabilitySnapshot::new(vec![
+        RoutingTargetAvailability::new(
+            degraded,
+            RoutingAvailabilityState::Degraded {
+                reason: "latency high".to_string(),
+            },
+        ),
+        RoutingTargetAvailability::new(healthy.clone(), RoutingAvailabilityState::Available),
+    ]);
+
+    let selection = policy.select(
+        &RoutingSelectionRequest::new("gpt-4o").with_degraded_allowed(true),
+        &availability,
+    )?;
+
+    assert_eq!(selection.selected_target, healthy);
+    assert_eq!(selection.decision_mode, RoutingDecisionMode::Fallback);
+    assert!(matches!(
+        selection.skipped_candidates[0].reason,
+        RoutingSkipReason::DegradedDeferred { .. }
+    ));
+    Ok(())
+}
+
+#[test]
+fn no_route_for_model_fails_structurally() {
+    let policy = RoutingPolicy::new(Vec::new());
+    let availability = RoutingAvailabilitySnapshot::new(Vec::new());
+
+    let error = policy.select(&RoutingSelectionRequest::new("unknown"), &availability);
+
+    assert!(matches!(
+        error,
+        Err(CoreError::Routing {
+            failure: RoutingFailure::NoRoute {
+                requested_model,
+                resolved_model,
+            }
+        }) if requested_model == "unknown" && resolved_model == "unknown"
+    ));
+}
+
+#[test]
+fn invalid_policy_returns_structured_core_error() {
+    let target = RoutingTarget::provider_account("openai", "primary");
+    let policy = RoutingPolicy::new(vec![ModelRoute::new(
+        " ",
+        vec![RoutingCandidate::new(target.clone())],
+    )]);
+    let availability = available_snapshot(vec![target]);
+
+    let error = policy.select(&RoutingSelectionRequest::new("gpt-4o"), &availability);
+
+    assert!(matches!(
+        error,
+        Err(CoreError::Routing {
+            failure: RoutingFailure::InvalidPolicy {
+                field: "routes.resolved_model",
+                ..
+            }
+        })
+    ));
+}
+
+fn policy_with_candidates(targets: Vec<RoutingTarget>) -> RoutingPolicy {
+    RoutingPolicy::new(vec![ModelRoute::new(
+        "gpt-4o",
+        targets.into_iter().map(RoutingCandidate::new).collect(),
+    )])
+    .with_fallback(FallbackBehavior::default())
+}
+
+fn available_snapshot(targets: Vec<RoutingTarget>) -> RoutingAvailabilitySnapshot {
+    RoutingAvailabilitySnapshot::new(
+        targets
+            .into_iter()
+            .map(|target| {
+                RoutingTargetAvailability::new(target, RoutingAvailabilityState::Available)
+            })
+            .collect(),
+    )
+}

--- a/crates/oxmux/tests/routing_policy.rs
+++ b/crates/oxmux/tests/routing_policy.rs
@@ -266,6 +266,42 @@ fn degraded_candidate_is_selected_only_when_allowed() -> Result<(), CoreError> {
         allowed.selected_state,
         RoutingAvailabilityState::Degraded { .. }
     ));
+    assert!(allowed.skipped_candidates.is_empty());
+    Ok(())
+}
+
+#[test]
+fn selected_degraded_fallback_is_not_reported_as_skipped() -> Result<(), CoreError> {
+    let first_degraded = RoutingTarget::provider_account("openai", "primary");
+    let second_degraded = RoutingTarget::provider_account("anthropic", "fallback");
+    let policy = policy_with_candidates(vec![first_degraded.clone(), second_degraded.clone()]);
+    let availability = RoutingAvailabilitySnapshot::new(vec![
+        RoutingTargetAvailability::new(
+            first_degraded.clone(),
+            RoutingAvailabilityState::Degraded {
+                reason: "latency high".to_string(),
+            },
+        ),
+        RoutingTargetAvailability::new(
+            second_degraded,
+            RoutingAvailabilityState::Degraded {
+                reason: "quota stale".to_string(),
+            },
+        ),
+    ]);
+
+    let selection = policy.select(
+        &RoutingSelectionRequest::new("gpt-4o").with_degraded_allowed(true),
+        &availability,
+    )?;
+
+    assert_eq!(selection.selected_target, first_degraded);
+    assert!(
+        !selection
+            .skipped_candidates
+            .iter()
+            .any(|candidate| candidate.target == selection.selected_target)
+    );
     Ok(())
 }
 

--- a/crates/oxmux/tests/routing_policy.rs
+++ b/crates/oxmux/tests/routing_policy.rs
@@ -331,6 +331,12 @@ fn healthy_fallback_wins_over_degraded_higher_priority_candidate() -> Result<(),
         selection.skipped_candidates[0].reason,
         RoutingSkipReason::DegradedDeferred { .. }
     ));
+    assert!(
+        !selection.skipped_candidates[0]
+            .reason
+            .message()
+            .contains("healthy fallback is available")
+    );
     Ok(())
 }
 

--- a/crates/oxmux/tests/routing_policy.rs
+++ b/crates/oxmux/tests/routing_policy.rs
@@ -97,6 +97,53 @@ fn fallback_disabled_returns_structured_failure() {
 }
 
 #[test]
+fn fallback_disabled_degraded_candidate_reports_disallowed_reason() {
+    let degraded = RoutingTarget::provider_account("openai", "primary");
+    let policy = policy_with_candidates(vec![degraded.clone()]);
+    let availability = RoutingAvailabilitySnapshot::new(vec![RoutingTargetAvailability::new(
+        degraded.clone(),
+        RoutingAvailabilityState::Degraded {
+            reason: "latency high".to_string(),
+        },
+    )]);
+    let request = RoutingSelectionRequest::new("gpt-4o").with_fallback_enabled(false);
+
+    let error = policy.select(&request, &availability);
+
+    assert!(matches!(
+        error,
+        Err(CoreError::Routing {
+            failure: RoutingFailure::FallbackDisabled { target, reason }
+        }) if target == degraded && matches!(reason, RoutingSkipReason::DegradedDisallowed { .. })
+    ));
+}
+
+#[test]
+fn fallback_disabled_selects_degraded_candidate_when_allowed() -> Result<(), CoreError> {
+    let degraded = RoutingTarget::provider_account("openai", "primary");
+    let policy = policy_with_candidates(vec![degraded.clone()]);
+    let availability = RoutingAvailabilitySnapshot::new(vec![RoutingTargetAvailability::new(
+        degraded.clone(),
+        RoutingAvailabilityState::Degraded {
+            reason: "latency high".to_string(),
+        },
+    )]);
+    let request = RoutingSelectionRequest::new("gpt-4o")
+        .with_fallback_enabled(false)
+        .with_degraded_allowed(true);
+
+    let selection = policy.select(&request, &availability)?;
+
+    assert_eq!(selection.selected_target, degraded);
+    assert!(matches!(
+        selection.selected_state,
+        RoutingAvailabilityState::Degraded { .. }
+    ));
+    assert!(selection.skipped_candidates.is_empty());
+    Ok(())
+}
+
+#[test]
 fn explicit_account_target_wins_over_priority_candidates() -> Result<(), CoreError> {
     let primary = RoutingTarget::provider_account("openai", "primary");
     let explicit = RoutingTarget::provider_account("anthropic", "team");
@@ -156,6 +203,38 @@ fn exhausted_candidates_fail_structurally() {
         Err(CoreError::Routing {
             failure: RoutingFailure::ExhaustedCandidates { skipped, .. }
         }) if skipped.len() == 2
+    ));
+}
+
+#[test]
+fn mixed_exhausted_and_degraded_candidates_are_not_degraded_only() {
+    let exhausted = RoutingTarget::provider_account("openai", "primary");
+    let degraded = RoutingTarget::provider_account("anthropic", "fallback");
+    let policy = policy_with_candidates(vec![exhausted.clone(), degraded.clone()]);
+    let availability = RoutingAvailabilitySnapshot::new(vec![
+        RoutingTargetAvailability::new(
+            exhausted,
+            RoutingAvailabilityState::Exhausted {
+                reason: "daily quota".to_string(),
+            },
+        ),
+        RoutingTargetAvailability::new(
+            degraded,
+            RoutingAvailabilityState::Degraded {
+                reason: "stale quota".to_string(),
+            },
+        ),
+    ]);
+
+    let error = policy.select(&RoutingSelectionRequest::new("gpt-4o"), &availability);
+
+    assert!(matches!(
+        error,
+        Err(CoreError::Routing {
+            failure: RoutingFailure::NoAvailableCandidates { skipped, .. }
+        }) if skipped.len() == 2
+            && matches!(skipped[0].reason, RoutingSkipReason::Exhausted { .. })
+            && matches!(skipped[1].reason, RoutingSkipReason::DegradedDisallowed { .. })
     ));
 }
 
@@ -253,6 +332,46 @@ fn invalid_policy_returns_structured_core_error() {
         Err(CoreError::Routing {
             failure: RoutingFailure::InvalidPolicy {
                 field: "routes.resolved_model",
+                ..
+            }
+        })
+    ));
+}
+
+#[test]
+fn invalid_request_returns_structured_request_error() {
+    let target = RoutingTarget::provider_account("openai", "primary");
+    let policy = policy_with_candidates(vec![target.clone()]);
+    let availability = available_snapshot(vec![target]);
+
+    let error = policy.select(&RoutingSelectionRequest::new(" "), &availability);
+
+    assert!(matches!(
+        error,
+        Err(CoreError::Routing {
+            failure: RoutingFailure::InvalidRequest {
+                field: "requested_model",
+                ..
+            }
+        })
+    ));
+}
+
+#[test]
+fn invalid_explicit_target_returns_structured_request_error() {
+    let target = RoutingTarget::provider_account("openai", "primary");
+    let policy = policy_with_candidates(vec![target.clone()]);
+    let availability = available_snapshot(vec![target]);
+    let request = RoutingSelectionRequest::new("gpt-4o")
+        .with_explicit_target(RoutingTarget::provider_account(" ", "primary"));
+
+    let error = policy.select(&request, &availability);
+
+    assert!(matches!(
+        error,
+        Err(CoreError::Routing {
+            failure: RoutingFailure::InvalidRequest {
+                field: "explicit_target",
                 ..
             }
         })

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,72 @@
+# OxideMux Architecture Intent
+
+OxideMux is split into a shared product engine and a platform shell so that the
+subscription proxy behaves the same on Linux, macOS, Windows, and headless test
+consumers.
+
+```text
+developer tool / local client
+  -> local OxideMux endpoint
+  -> oxmux protocol + request rewrite pipeline
+  -> oxmux model alias + reasoning/thinking normalization
+  -> oxmux subscription-aware routing policy
+  -> provider/account execution seam
+  -> compatible response stream or response body
+
+platform shell
+  -> displays auth, quota, routing, health, and lifecycle state
+  -> supplies platform credential adapters and user choices
+  -> starts/stops/backgrounds the shared runtime
+```
+
+## `oxmux` owns shared behavior
+
+`oxmux` is the reusable Rust core. It owns behavior that must be deterministic,
+testable, and available outside the desktop app:
+
+- local proxy runtime contracts and lifecycle handles;
+- protocol families and request/response translation boundaries;
+- request rewrite primitives, compatibility shims, and provider-specific
+  payload semantics;
+- reasoning/thinking-mode normalization and token/budget semantics;
+- model aliases and explicit provider/account targets;
+- subscription-aware routing inputs, selection outcomes, degraded/exhausted
+  states, and structured routing errors;
+- provider execution traits, mock harnesses, and account/capability summaries;
+- usage/quota summaries, management snapshots, and configuration state.
+
+The core may describe auth/session semantics and credential references, but it
+must not own OAuth UI, platform secret-store implementation, GPUI state, tray
+libraries, packaging, updaters, or provider SDK dependencies unless an accepted
+OpenSpec change explicitly revises the boundary.
+
+## `oxidemux` owns platform behavior
+
+`oxidemux` is the app shell. It owns behavior that exists because users need a
+native app on Linux, macOS, and Windows:
+
+- GPUI windows, views, settings, dashboards, themes, and interaction flows;
+- tray/menu-bar integration and platform-specific lifecycle policy;
+- notifications, start-on-login, background behavior, packaging, and updater UX;
+- platform credential storage adapters and browser/OAuth presentation flows;
+- user-visible subscription onboarding, restore, auth repair, and account
+  selection flows;
+- presentation of core state: quota pressure, account health, provider status,
+  selected route, fallback reason, and next recovery action.
+
+The shell must not duplicate routing, provider, quota, request rewrite,
+thinking/reasoning, protocol, or management decision logic. It supplies inputs
+to `oxmux` and renders outputs from `oxmux`.
+
+## Boundary test
+
+Before adding behavior, ask:
+
+1. Does this need to run in headless tests or from a non-GPUI Rust consumer?
+   Put the semantics in `oxmux`.
+2. Does this require a desktop OS, window, tray/menu, updater, notification, or
+   platform credential store? Put the implementation in `oxidemux` or an
+   app-owned adapter.
+3. Does this affect subscription UX, auth/session behavior, request rewriting,
+   model aliases, thinking/reasoning behavior, routing, or crate boundaries?
+   Update OpenSpec before implementation.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,0 +1,76 @@
+# OxideMux Vision
+
+OxideMux exists because VibeProxy and zero-limit prove that developers want
+subscription-aware local AI proxying, but they do not provide the cross-platform
+Linux, macOS, and Windows experience this project needs. The product center is
+subscription UX: users should understand account status, auth health,
+quota/rate-limit pressure, provider availability, routing behavior, and recovery
+paths without reading logs or hand-editing proxy state.
+
+OxideMux should feel like a native always-on utility. The tray/menu experience
+must have platform-appropriate implementations on Linux, macOS, and Windows, but
+those shells adapt shared behavior rather than redefining it.
+
+## Product references
+
+- CLIProxyAPI validates the headless proxy/API boundary: provider auth,
+  protocol compatibility, routing, model aliases, fallback, streaming, and
+  management endpoints need reusable contracts.
+- zero-limit validates the desktop control surface: quota visibility,
+  proxy lifecycle controls, tray/background operation, themes, and updates are
+  real product requirements.
+- VibeProxy validates the subscription-first local proxy UX: auth/session flows,
+  model aliasing, request compatibility shims, provider-specific routing, and
+  reasoning or thinking-mode request rewriting are core product behavior, not
+  optional polish.
+
+OxideMux is an independent Rust implementation of those product lessons with a
+clearer shared-core boundary and first-class cross-platform support.
+
+## Core product intent
+
+- Subscription UX is the star of the application, not an add-on to a generic
+  proxy.
+- Local clients should keep using familiar OpenAI-compatible or provider-shaped
+  APIs while OxideMux normalizes requests, maps aliases, applies reasoning or
+  thinking options, routes across accounts/providers, and returns compatible
+  responses.
+- Provider availability, subscription state, quota pressure, degraded states,
+  and fallback decisions must be represented as typed state that can be tested
+  without a desktop shell.
+- Auth redirects, cookies, credential references, and provider session health
+  must be treated as user-facing product flows because broken auth is broken
+  subscription UX.
+- Desktop UI should explain what the core is doing: which account/provider was
+  chosen, why fallback happened, what quota/auth state blocks a route, and what
+  the user can do next.
+
+## Crate responsibility rule
+
+`oxmux` is the shared headless product engine. It owns provider protocols, auth
+semantics, request rewriting, reasoning/thinking compatibility primitives,
+model aliases, routing policy, management/status contracts, configuration,
+usage/quota state, and testable decision logic.
+
+`oxidemux` is the platform shell. It owns GPUI views, tray/menu integration,
+windows, notifications, packaging, updater behavior, platform credential storage
+adapters, and OS-specific lifecycle UX.
+
+Use this rule when placing new behavior:
+
+> If behavior must work in CLI/headless tests, put it in `oxmux`. If behavior
+> exists only because a desktop OS, GPUI, tray, packaging, or platform storage
+> exists, put it in `oxidemux` or an app-owned adapter.
+
+## What future agents must preserve
+
+- Do not reduce VibeProxy or zero-limit to vague inspiration. Treat them as
+  validated product references with an unresolved Linux/cross-platform gap.
+- Do not move subscription-aware routing, request rewrite, model alias,
+  thinking/reasoning, or protocol compatibility behavior into the desktop shell
+  just because the UI exposes it.
+- Do not start with tray, packaging, themes, or updater work if the core cannot
+  yet accept, normalize, route, execute, and return a minimal proxy request.
+- Do not make `oxmux` depend on GPUI, tray libraries, provider SDKs, platform
+  secret stores, or OAuth UI. The core can define typed semantics and seams;
+  shell/platform adapters provide concrete OS integrations.

--- a/openspec/changes/add-routing-policy-primitives/.openspec.yaml
+++ b/openspec/changes/add-routing-policy-primitives/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-28

--- a/openspec/changes/add-routing-policy-primitives/design.md
+++ b/openspec/changes/add-routing-policy-primitives/design.md
@@ -1,0 +1,70 @@
+## Context
+
+`oxmux` already owns the headless core boundary, provider execution mocks, protocol metadata, configuration snapshots, management summaries, and a placeholder `RoutingBoundary`. Issue #5 moves routing from placeholder ownership to typed policy primitives so later configuration, proxy execution, credential selection, quota-aware failover, model listing, and reasoning-budget work can depend on stable routing contracts.
+
+The implementation must remain inside `crates/oxmux` and use deterministic typed inputs. Provider integrations, quota fetching, concrete proxy routing, GPUI, `oxidemux`, credential storage, and app-shell lifecycle code remain outside this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define Rust-native routing policy types for model aliases, priority order, fallback behavior, explicit provider/account targeting, and provider/account availability.
+- Provide a deterministic selection function that returns typed success or structured `CoreError` routing failures.
+- Represent degraded and exhausted provider/account states from caller-supplied inputs without fetching live quota or health data.
+- Export the routing policy primitives from the `oxmux` public facade for direct Rust consumers.
+- Cover routing behavior with networkless tests in the `oxmux` crate.
+
+**Non-Goals:**
+
+- No outbound provider calls, provider SDKs, HTTP clients, OAuth, token refresh, or credential storage.
+- No payload rewrite DSL, cloaking/obfuscation, prompt mutation, or agent-client-specific routing tables.
+- No app-shell, GPUI, tray, updater, or desktop lifecycle integration.
+- No automatic quota polling or live health discovery; exhausted/degraded state is explicit input supplied by mocks, configuration, or future management layers.
+
+## Decisions
+
+1. **Keep policy and runtime state separate.**
+   - Decision: `RoutingPolicy` describes aliases, priority candidates, fallback behavior, and optional explicit targets; a separate availability snapshot describes provider/account state for a selection attempt.
+   - Rationale: Policies should be reusable and serializable later, while availability can change per request without mutating the policy.
+   - Alternative considered: storing availability directly on policy entries. That would blur configuration with runtime state and make deterministic tests less precise.
+
+2. **Return an auditable selection outcome instead of only a provider/account pair.**
+   - Decision: selection returns a typed outcome with selected provider, optional account, requested model, resolved model, decision mode, and skipped candidate reasons.
+   - Rationale: Future UI and management endpoints need explainability without parsing logs or display strings.
+   - Alternative considered: returning only the chosen target. That would be simpler but would hide fallback and degraded/exhausted reasoning from callers.
+
+3. **Use structured `CoreError` variants for terminal routing failures.**
+   - Decision: add routing-specific structured failure data to `CoreError` for invalid policy, missing target, no route, exhausted candidates, and degraded-only candidates when degraded fallback is disallowed.
+   - Rationale: Downstream code must match errors directly and present meaningful feedback without string parsing.
+   - Alternative considered: defining a routing-only error type and converting later. That fragments the core error boundary and makes app-shell propagation inconsistent.
+
+4. **Model aliases resolve before candidate selection.**
+   - Decision: the requested model is first resolved through alias rules, then provider/account candidates are evaluated in deterministic priority order.
+   - Rationale: Alias behavior must be testable independently and should not vary by provider integration state.
+   - Alternative considered: provider-specific alias resolution during execution. That would defer core routing decisions to provider implementations and weaken the headless core contract.
+
+5. **Fallback policy is explicit.**
+   - Decision: routing only tries lower-priority candidates when fallback is enabled for the policy or selection request; degraded candidates are selectable only when explicitly allowed.
+   - Rationale: This prevents surprising provider/account changes and keeps degraded service behavior visible to users.
+   - Alternative considered: always fall back to any non-exhausted candidate. That maximizes availability but can violate user intent and account targeting expectations.
+
+## Risks / Trade-offs
+
+- [Risk] Routing primitives overfit early mock scenarios before real provider integrations exist. → Mitigation: keep types small, headless, and focused on selection inputs/results rather than provider transport details.
+- [Risk] Explicit degraded handling adds more states for callers. → Mitigation: return skipped-candidate metadata and structured failures so callers can explain why no healthy route was selected.
+- [Risk] Public API may need refinement when file-backed configuration arrives. → Mitigation: isolate policy data models in `routing` and export through the facade so future configuration loading can construct the same types.
+- [Risk] Core facade growth could accidentally pull app dependencies. → Mitigation: keep implementation in `crates/oxmux`, avoid new non-core dependencies, and extend dependency-boundary tests.
+
+## Migration Plan
+
+1. Add routing policy, target, availability, outcome, and failure primitives in `crates/oxmux/src/routing.rs`.
+2. Export new routing types from `crates/oxmux/src/oxmux.rs`.
+3. Add routing-specific `CoreError` support in `crates/oxmux/src/errors.rs`.
+4. Add deterministic `crates/oxmux/tests/routing_policy.rs` coverage for the issue acceptance criteria.
+5. Run `cargo fmt`, `cargo test -p oxmux`, and workspace CI tasks to confirm the core remains dependency-light.
+
+Rollback is straightforward before downstream issues depend on these types: remove the new routing exports, error variants, and tests while leaving the placeholder `RoutingBoundary` intact.
+
+## Open Questions
+
+- None for this proposal. Later provider integration work can refine how live provider health populates the explicit availability inputs without changing the core selection contract.

--- a/openspec/changes/add-routing-policy-primitives/proposal.md
+++ b/openspec/changes/add-routing-policy-primitives/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Provider selection needs typed, deterministic routing policy primitives before real provider integrations land so downstream app and UI layers can rely on matchable outcomes instead of parsing strings or embedding routing rules in app-shell code.
+
+## What Changes
+
+- Add headless `oxmux` routing policy configuration for model aliases, priority order, fallback behavior, explicit provider/account targeting, and provider/account availability states.
+- Expose typed routing selection results that identify the selected provider, account, resolved model, routing decision path, and skipped candidates.
+- Surface routing failures through structured `CoreError` values for no-match, exhausted, degraded-only, missing target, and invalid policy cases.
+- Add deterministic networkless tests covering model aliasing, priority order, fallback, explicit account targeting, and exhausted/degraded providers.
+- Keep routing policy behavior independent of GPUI, `oxidemux`, real provider calls, quota fetching, payload rewrite DSLs, cloaking/obfuscation, and agent-client-specific routing tables.
+
+## Capabilities
+
+### New Capabilities
+
+- `oxmux-routing-policy`: Typed routing policy configuration, provider/account availability inputs, selection outcomes, and routing failure contracts for deterministic headless provider selection.
+
+### Modified Capabilities
+
+- `oxmux-core`: Public facade and core error requirements expand from reserving routing ownership to exposing typed routing policy primitives and structured routing failures.
+
+## Impact
+
+- Affected crate: `crates/oxmux` only.
+- Affected modules: `routing`, `errors`, public facade exports in `oxmux.rs`, and deterministic `oxmux` tests.
+- API impact: new public Rust types for routing policy configuration, provider/account targets, availability state, selection results, skipped candidates, and routing failure details.
+- Dependency impact: no new provider SDK, HTTP, OAuth, GPUI, app-shell, credential storage, or external service dependencies.

--- a/openspec/changes/add-routing-policy-primitives/specs/oxmux-core/spec.md
+++ b/openspec/changes/add-routing-policy-primitives/specs/oxmux-core/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: Minimal public facade for future core domains
+The `oxmux` crate SHALL expose a small public facade that establishes ownership of proxy lifecycle, local health runtime, provider/auth, provider execution, routing, protocol translation, configuration, streaming, management/status, usage/quota, and domain error primitives without implementing full provider SDK integration, outbound provider calls, credential storage, or concrete proxy request handling in this change.
+
+#### Scenario: Provider auth ownership is visible but not implemented
+- **WHEN** maintainers inspect the `oxmux` public API or documentation
+- **THEN** provider authentication and token refresh are identified as future core concerns without requiring OAuth UI, platform credential storage, or concrete provider clients in this phase
+
+#### Scenario: Provider execution ownership exposes deterministic mock boundaries
+- **WHEN** maintainers inspect the `oxmux` public API or documentation after adding provider execution primitives
+- **THEN** provider execution is represented by trait, request, result, mock harness, and structured outcome primitives that can be used in deterministic tests without requiring real provider SDKs, HTTP clients, OAuth, platform credential storage, GPUI, or app-shell state
+
+#### Scenario: Routing ownership exposes typed policy primitives
+- **WHEN** maintainers inspect the `oxmux` public API or documentation after adding routing policy primitives
+- **THEN** model aliases, account targeting, priority, fallback, exhausted states, degraded states, selection outcomes, skipped candidate metadata, and routing failure details are represented by typed public primitives without requiring concrete proxy routing behavior, provider SDKs, outbound provider calls, GPUI, or app-shell state
+
+#### Scenario: Protocol ownership exposes typed skeleton boundaries
+- **WHEN** maintainers inspect the `oxmux` public API or documentation
+- **THEN** OpenAI, Gemini, Claude, Codex, and provider-specific protocol translation are represented by typed request/response boundaries, typed protocol metadata, and deferred translation results without requiring request translators, response translators, or outbound provider calls in this phase
+
+#### Scenario: Streaming ownership is visible but not implemented
+- **WHEN** maintainers inspect the `oxmux` public API or documentation
+- **THEN** streaming and non-streaming response support are identified as future core concerns without requiring network transports or provider stream adapters in this phase
+
+#### Scenario: Management ownership includes local health runtime status
+- **WHEN** maintainers inspect the `oxmux` public API or documentation
+- **THEN** proxy lifecycle state, local health runtime status, provider listing, account health, usage, quota, and degraded service status are identified as core concerns while management endpoints beyond `/health` remain deferred
+
+### Requirement: Core errors remain visible to consumers
+The `oxmux` crate SHALL define or reserve a core error boundary so future fallible proxy, provider, configuration, routing, protocol, streaming, and management operations can propagate meaningful errors to library consumers and app layers, including structured routing failures that callers can match without parsing display text.
+
+#### Scenario: Core error type is usable by the app shell
+- **WHEN** `oxidemux` calls into the `oxmux` facade
+- **THEN** fallible operations expose typed or structured errors that can be propagated or displayed rather than silently discarded
+
+#### Scenario: Routing failures are matchable
+- **WHEN** `oxmux` route selection fails because a route is missing, a target is missing, candidates are exhausted, only degraded candidates remain, or policy input is invalid
+- **THEN** the returned `CoreError` includes structured routing failure data that Rust consumers can match without parsing display text

--- a/openspec/changes/add-routing-policy-primitives/specs/oxmux-routing-policy/spec.md
+++ b/openspec/changes/add-routing-policy-primitives/specs/oxmux-routing-policy/spec.md
@@ -1,0 +1,81 @@
+## ADDED Requirements
+
+### Requirement: Typed routing policy configuration
+The `oxmux` core SHALL expose typed routing policy configuration primitives for model aliases, ordered provider/account candidates, fallback behavior, explicit provider/account targeting, and caller-supplied provider/account availability states without depending on GPUI, `oxidemux`, provider SDKs, HTTP clients, OAuth flows, credential storage, live quota fetching, or outbound provider network calls.
+
+#### Scenario: Policy config represents model aliasing
+- **WHEN** a Rust consumer configures a routing policy with a model alias from a public model name to a canonical provider model name
+- **THEN** the policy can be constructed and inspected through typed `oxmux` primitives without parsing strings outside the model identifier values themselves
+
+#### Scenario: Policy config represents ordered candidates
+- **WHEN** a Rust consumer configures multiple provider/account candidates for a resolved model
+- **THEN** the policy preserves deterministic priority order for selection tests and future proxy routing behavior
+
+#### Scenario: Policy config represents explicit targeting
+- **WHEN** a Rust consumer configures an explicit provider target with or without an explicit account target
+- **THEN** the routing policy can represent that target separately from priority fallback candidates
+
+#### Scenario: Policy config remains headless
+- **WHEN** maintainers inspect or test routing policy configuration primitives
+- **THEN** the `oxmux` crate remains free of GPUI, app-shell, provider SDK, HTTP, OAuth, token refresh, credential storage, and live quota-fetching dependencies
+
+### Requirement: Deterministic route selection outcomes
+The `oxmux` core SHALL provide deterministic routing selection behavior that resolves model aliases before selecting from explicit targets or ordered candidates and returns typed selection results containing the requested model, resolved model, selected provider, selected account when present, decision mode, and skipped candidate metadata.
+
+#### Scenario: Model alias resolves before selection
+- **WHEN** a request asks for a model alias that maps to a canonical model with available candidates
+- **THEN** route selection returns a typed result containing both the requested alias and the resolved canonical model
+
+#### Scenario: Priority order selects first available candidate
+- **WHEN** multiple candidates are configured and the highest-priority candidate is available
+- **THEN** route selection returns the highest-priority provider/account candidate without evaluating lower-priority candidates as selected
+
+#### Scenario: Fallback skips unavailable candidate
+- **WHEN** fallback is enabled and the highest-priority candidate is exhausted or unavailable
+- **THEN** route selection skips that candidate with typed skip metadata and selects the next available candidate in deterministic order
+
+#### Scenario: Fallback disabled fails before lower-priority selection
+- **WHEN** fallback is disabled and the highest-priority candidate is exhausted or unavailable
+- **THEN** route selection returns a structured `CoreError` instead of selecting a lower-priority candidate
+
+#### Scenario: Explicit account targeting wins over fallback candidates
+- **WHEN** a request includes an explicit provider/account target and that target is available
+- **THEN** route selection returns the explicit target rather than a different priority or fallback candidate
+
+#### Scenario: Degraded provider selection requires permission
+- **WHEN** only degraded candidates remain and degraded routing is explicitly allowed
+- **THEN** route selection may return a degraded candidate with typed metadata indicating that degraded state influenced the decision
+
+### Requirement: Structured routing failures
+Routing failures in `oxmux` SHALL surface as structured `CoreError` values with matchable routing failure details rather than display strings.
+
+#### Scenario: Missing explicit target fails structurally
+- **WHEN** a request targets a provider/account pair that is not present in the routing availability input
+- **THEN** route selection returns a structured `CoreError` describing the missing target without falling back silently
+
+#### Scenario: Exhausted candidates fail structurally
+- **WHEN** every candidate for the resolved model is exhausted
+- **THEN** route selection returns a structured `CoreError` describing exhausted routing candidates
+
+#### Scenario: Degraded-only candidates fail when degraded routing is disallowed
+- **WHEN** every remaining candidate is degraded and degraded routing is not allowed
+- **THEN** route selection returns a structured `CoreError` describing degraded-only routing candidates
+
+#### Scenario: No route for model fails structurally
+- **WHEN** a request asks for a model with no alias mapping and no candidates
+- **THEN** route selection returns a structured `CoreError` describing the missing route for that model
+
+#### Scenario: Invalid policy fails structurally
+- **WHEN** a routing policy contains invalid data such as an empty model identifier, duplicate ambiguous aliases, or an explicit target that cannot be represented as a provider/account target
+- **THEN** route selection or policy validation returns a structured `CoreError` describing the invalid policy field without panicking or silently ignoring the invalid input
+
+### Requirement: Routing tests remain networkless
+Default `oxmux` routing policy tests SHALL use deterministic in-memory policies and availability inputs, and SHALL NOT require real provider accounts, credentials, provider SDKs, outbound provider network calls, OAuth flows, token refresh, platform secret storage, GPUI, or `oxidemux` app-shell dependencies.
+
+#### Scenario: Tests cover required routing modes
+- **WHEN** maintainers run default `oxmux` tests for routing policy primitives
+- **THEN** deterministic tests cover model aliasing, priority order, fallback enabled, fallback disabled, explicit account targeting, exhausted providers, degraded providers, and invalid policy failures without external services
+
+#### Scenario: Routing tests preserve core dependency boundary
+- **WHEN** maintainers inspect or run routing policy tests
+- **THEN** the tests use only `oxmux` core primitives and do not depend on GPUI, `oxidemux`, provider SDKs, HTTP clients, OAuth flows, credential storage, or live quota fetching

--- a/openspec/changes/add-routing-policy-primitives/tasks.md
+++ b/openspec/changes/add-routing-policy-primitives/tasks.md
@@ -1,0 +1,30 @@
+## 1. Routing Policy Contracts
+
+- [x] 1.1 Replace the placeholder routing boundary with typed routing policy, model alias, provider/account target, candidate, fallback, and availability primitives in `crates/oxmux/src/routing.rs`.
+- [x] 1.2 Add typed selection request, selection result, decision mode, skipped candidate, and failure-detail primitives in `crates/oxmux/src/routing.rs`.
+- [x] 1.3 Implement deterministic model alias resolution that preserves both requested and resolved model identifiers in selection results.
+- [x] 1.4 Implement deterministic candidate evaluation for explicit targets, priority order, fallback enabled, fallback disabled, exhausted candidates, unavailable candidates, and degraded candidates.
+- [x] 1.5 Keep routing policy and per-selection availability state separate so policies remain reusable while exhausted/degraded inputs can vary per request.
+
+## 2. Core Facade and Errors
+
+- [x] 2.1 Export the new routing policy primitives from `crates/oxmux/src/oxmux.rs` for direct Rust consumers.
+- [x] 2.2 Add routing-specific structured `CoreError` support for invalid policy, no route, missing explicit target, exhausted candidates, and degraded-only candidates.
+- [x] 2.3 Ensure routing failure display text is human-readable while tests and consumers can still match structured error data without parsing strings.
+- [x] 2.4 Preserve the `oxmux` dependency boundary by avoiding GPUI, `oxidemux`, provider SDK, HTTP, OAuth, token refresh, credential storage, and live quota-fetching dependencies.
+
+## 3. Deterministic Test Coverage
+
+- [x] 3.1 Add `crates/oxmux/tests/routing_policy.rs` coverage for model aliasing and typed requested/resolved model results.
+- [x] 3.2 Add tests proving priority order selects the first available candidate and records skipped candidates when fallback occurs.
+- [x] 3.3 Add tests proving explicit provider/account targeting wins over priority fallback when available and fails structurally when missing.
+- [x] 3.4 Add tests for fallback-disabled failures, exhausted candidates, degraded candidates when allowed, and degraded-only failures when degraded routing is disallowed.
+- [x] 3.5 Add tests for invalid policy failures that return structured `CoreError` values without panics or silent ignores.
+- [x] 3.6 Update dependency-boundary tests if needed to prove routing policy primitives remain headless and networkless.
+
+## 4. Verification
+
+- [x] 4.1 Run `cargo fmt --all --check` and fix formatting issues.
+- [x] 4.2 Run `cargo test -p oxmux` and fix routing/core test failures.
+- [x] 4.3 Run `mise run ci` to verify workspace formatting, checking, clippy, and tests.
+- [x] 4.4 Run `openspec validate add-routing-policy-primitives --strict` and fix any OpenSpec validation issues.

--- a/openspec/specs/oxidemux-app-shell/spec.md
+++ b/openspec/specs/oxidemux-app-shell/spec.md
@@ -3,6 +3,12 @@
 Define the `oxidemux` app shell boundary as the desktop and integration consumer
 of the reusable `oxmux` core crate.
 
+`oxidemux` exists to make the shared subscription proxy understandable and
+controllable through native Linux, macOS, and Windows surfaces. The shell owns
+presentation, platform lifecycle, and OS integration; it consumes core state and
+supplies platform inputs without duplicating `oxmux` routing, request rewrite,
+thinking/reasoning, provider, quota, or protocol decisions.
+
 ## Requirements
 
 ### Requirement: App shell consumes core crate
@@ -30,6 +36,17 @@ The `oxidemux` crate SHALL be the owner of future GPUI UI, settings UX, dashboar
 #### Scenario: Credential storage boundary remains explicit
 - **WHEN** future secure credential storage work is planned
 - **THEN** platform-specific storage implementations belong to `oxidemux` or app/platform adapters while reusable credential abstractions belong to `oxmux`
+
+### Requirement: App shell owns cross-platform subscription UX
+The `oxidemux` app shell SHALL provide platform-appropriate Linux, macOS, and Windows tray/menu and window surfaces for subscription onboarding, auth repair, account selection, quota/rate-limit visibility, provider availability, selected-route explanation, fallback visibility, and proxy lifecycle control while delegating shared proxy semantics to `oxmux`.
+
+#### Scenario: Tray and menu behavior remains cross-platform
+- **WHEN** future tray/menu or menu-bar behavior is designed for one desktop platform
+- **THEN** the app-shell design identifies equivalent Linux, macOS, and Windows affordances or documents a platform limitation without moving shared proxy logic out of `oxmux`
+
+#### Scenario: Subscription dashboard consumes core state
+- **WHEN** future GPUI dashboard work displays auth health, quota pressure, provider status, selected route, fallback reason, or recovery guidance
+- **THEN** it renders data from `oxmux` management, routing, provider/account, usage/quota, and error contracts instead of reimplementing the decisions in app-only state
 
 ### Requirement: App shell separates UI-visible state from core behavior
 The `oxidemux` crate SHALL adapt core state into user-visible UI or integration state without duplicating core routing, provider, quota, or protocol logic.

--- a/openspec/specs/oxmux-core/spec.md
+++ b/openspec/specs/oxmux-core/spec.md
@@ -2,6 +2,13 @@
 
 Define the `oxmux` headless Rust core crate boundary for direct library use
 without desktop UI, platform lifecycle, or app-shell dependencies.
+
+`oxmux` is the shared product engine for subscription-aware local proxying. It
+owns reusable semantics for protocol compatibility, request rewriting, model
+aliases, reasoning/thinking compatibility primitives, subscription-aware routing,
+provider/account state, management snapshots, usage/quota state, and structured
+errors. Desktop shells and platform adapters provide UI and OS integrations, but
+they must not redefine those core semantics.
 ## Requirements
 ### Requirement: Headless core crate boundary
 The system SHALL provide an `oxmux` Rust library crate that is usable without GPUI, desktop lifecycle code, tray integration, updater logic, packaging code, app-specific UI dependencies, provider execution dependencies, OAuth UI, or platform credential storage dependencies while owning reusable local proxy runtime behavior.
@@ -40,6 +47,17 @@ The `oxmux` crate SHALL expose a small public facade that establishes ownership 
 #### Scenario: Management ownership includes local health runtime status
 - **WHEN** maintainers inspect the `oxmux` public API or documentation
 - **THEN** proxy lifecycle state, local health runtime status, provider listing, account health, usage, quota, and degraded service status are identified as core concerns while management endpoints beyond `/health` remain deferred
+
+### Requirement: Core owns subscription proxy semantics
+The `oxmux` crate SHALL own the reusable subscription-aware proxy semantics needed to normalize local AI requests, represent model aliases, expose reasoning/thinking request compatibility primitives, accept app-supplied provider/account availability, route requests through deterministic policy, and return structured outcomes without depending on GPUI, tray/menu libraries, OAuth UI, platform credential storage, provider SDKs, or the `oxidemux` app shell.
+
+#### Scenario: Thinking and model compatibility are core primitives
+- **WHEN** future local proxy request handling accepts provider-shaped or OpenAI-compatible requests that include model aliases, reasoning budgets, or thinking-mode conventions
+- **THEN** the normalization, typed metadata, and routing-relevant semantics are exposed through `oxmux` primitives while desktop-specific controls remain in `oxidemux`
+
+#### Scenario: Subscription state is supplied without shell-owned routing
+- **WHEN** future app or platform adapters know account auth health, quota pressure, subscription availability, degraded state, or user-selected provider/account preferences
+- **THEN** they pass typed availability inputs or credential references into `oxmux`, and `oxmux` owns the route selection, fallback reason, and structured failure outcome
 
 ### Requirement: Core errors remain visible to consumers
 The `oxmux` crate SHALL define or reserve a core error boundary so future fallible proxy, provider, configuration, routing, protocol, streaming, and management operations can propagate meaningful errors to library consumers and app layers.
@@ -80,4 +98,3 @@ The `oxmux` management/lifecycle and provider execution facade SHALL remain usab
 #### Scenario: Protocol ownership remains explicit
 - **WHEN** provider capabilities, provider execution requests, or routing defaults reference OpenAI, Gemini, Claude, Codex, or provider-specific protocol families
 - **THEN** the facade identifies those protocol families as typed metadata but does not translate requests or responses in this change
-


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #5

## ✅ Type of Change

- [x] ✨ New Project/Feature
- [ ] 🐞 Bug Fix
- [x] 📚 Documentation Update
- [ ] 🔨 Refactor or Other

## 📝 Summary

- Add deterministic `oxmux` routing policy primitives for model aliases, fallback behavior, target availability, degraded/exhausted states, and structured routing failures.
- Expose routing primitives through the public facade and cover selection behavior with routing policy tests.
- Document product guardrails so subscription UX, VibeProxy-style request rewrite/thinking semantics, and core-vs-shell ownership remain explicit.

## 📐 OpenSpec Evidence

- OpenSpec change/spec: `openspec/changes/add-routing-policy-primitives/`, `openspec/specs/oxmux-core/spec.md`, `openspec/specs/oxidemux-app-shell/spec.md`
- No OpenSpec required: N/A
- Vision/boundary impact: Preserves `docs/vision.md` and `docs/architecture.md` by keeping routing semantics in `oxmux` and desktop/platform UX in `oxidemux`.

## 📖 Documentation Checklist

- [x] I updated `README.md`, `CONTRIBUTING.md`, or OpenSpec docs when needed.
- [x] I updated `CHANGELOG.md` for notable user-facing, compatibility, security, or workflow changes, or explained why it was not applicable. Not applicable: unreleased core primitives and OpenSpec/docs updates are covered by repository docs in this PR.

## ✔️ Contributor Checklist

- [x] My code follows the project's coding standards.
- [x] I have added a `.env.example` file if environment variables are needed and ensured no secrets are committed.
- [x] My pull request is focused on a single project or change.
- [x] I preserved the `oxmux` shared-core and `oxidemux` platform-shell boundary, or documented the OpenSpec-approved reason for changing it.
- [x] I ran `mise run ci` locally, or explained why it was not applicable.
- [x] I ran relevant hk checks with `mise run hk-check`, or explained why they were not applicable. Not applicable: `mise run ci` exercised fmt, check, clippy, and tests for this change.

## 💬 Additional Comments

Release Notes:

- N/A