### PR TITLE
Migrate CI to Blacksmith runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   quality:
     name: Quality
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-2vcpu-ubuntu-2404
 
     steps:
       - name: Checkout
@@ -44,9 +44,9 @@ jobs:
       fail-fast: false
       matrix:
         runner:
-          - ubuntu-latest
-          - macos-latest
-          - windows-latest
+          - blacksmith-2vcpu-ubuntu-2404
+          - blacksmith-6vcpu-macos-latest
+          - blacksmith-2vcpu-windows-2025
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## 🔗 Linked Issue

N/A

## ✅ Type of Change

- [ ] ✨ New Project/Feature
- [ ] 🐞 Bug Fix
- [ ] 📚 Documentation Update
- [x] 🔨 Refactor or Other

## 📝 Summary

- Migrates CI jobs from GitHub-hosted runner labels to Blacksmith runner labels.
- Keeps existing checkout and mise setup actions so the workflow continues to use upstream actions with Blacksmith's transparent cache layer.

## 📐 OpenSpec Evidence

- OpenSpec change/spec: N/A
- No OpenSpec required: CI runner infrastructure migration only; no product behavior, public API, workflow policy semantics, provider/protocol semantics, GPUI behavior, or cross-crate boundary changes.
- Vision/boundary impact: No impact to subscription UX, auth/session behavior, request rewrite, model aliases, reasoning/thinking compatibility, routing, provider selection, or crate boundaries.

## 📖 Documentation Checklist

- [x] I updated `README.md`, `CONTRIBUTING.md`, or OpenSpec docs when needed. Not needed; no user-facing docs changed.
- [x] I updated `CHANGELOG.md` for notable user-facing, compatibility, security, or workflow changes, or explained why it was not applicable. Not applicable; CI infrastructure-only change.

## ✔️ Contributor Checklist

- [x] My code follows the project's coding standards.
- [x] I have added a `.env.example` file if environment variables are needed and ensured no secrets are committed. Not applicable; no environment variables added.
- [x] My pull request is focused on a single project or change.
- [x] I preserved the `oxmux` shared-core and `oxidemux` platform-shell boundary, or documented the OpenSpec-approved reason for changing it.
- [x] I ran `mise run ci` locally, or explained why it was not applicable.
- [x] I ran relevant hk checks with `mise run hk-check`, or explained why they were not applicable.

## 💬 Additional Comments

Validation performed:

- `mise run ci`
- `mise run hk-check`
- `git diff --check`
- Workflow runner label check for Blacksmith labels

Release Notes:

- N/A

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WeShipWork/codesmith/oxidemux/pr/37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->