### PR TITLE
Adopt production readiness workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -52,6 +52,7 @@ Please confirm that you have followed these guidelines.
 - [ ] My pull request is focused on a single project or change.
 - [ ] I preserved the `oxmux` shared-core and `oxidemux` platform-shell boundary, or documented the OpenSpec-approved reason for changing it.
 - [ ] I ran `mise run ci` locally, or explained why it was not applicable.
+- [ ] I ran `mise run security` locally for dependency policy and vulnerability changes, or explained why it was not applicable.
 - [ ] I ran relevant hk checks with `mise run hk-check`, or explained why they were not applicable.
 
 ## 💬 Additional Comments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up mise
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
         with:
           install: true
           cache: true
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up mise
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
         with:
           install: true
           cache: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up mise
-        uses: jdx/mise-action@v3
+        uses: jdx/mise-action@v4
         with:
           install: true
           cache: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,33 @@
+name: Security
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  schedule:
+    - cron: '23 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  security:
+    name: Security
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up mise
+        uses: jdx/mise-action@v3
+        with:
+          install: true
+          cache: true
+          experimental: true
+
+      - name: Run security verification
+        run: mise run security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,4 +31,5 @@ as release boundaries become established.
 
 ### Security
 
-- N/A
+- Added mise-backed `cargo-deny` and `cargo-audit` verification with an initial
+  repository supply-chain policy.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,12 +23,40 @@ Run the same verification contract CI uses:
 
 ```bash
 mise run ci
+mise run security
 mise run hk-check
 ```
 
 `mise.toml` is the source of truth for workflow tools and verification tasks.
 When Rust is upgraded, keep the `rust` pin in `mise.toml` aligned with
-`rust-toolchain.toml`.
+`rust-toolchain.toml`. Security tools are also invoked through mise: use
+`mise run security` for the full dependency policy and vulnerability gate, or
+`mise run deny` and `mise run audit` when you need a narrower check.
+
+## Security and supply-chain policy
+
+OxideMux keeps supply-chain exceptions explicit and reviewable. If
+`cargo-deny` reports an advisory, license, duplicate dependency, registry, or
+git-source exception that the project must accept, record the exception in
+`deny.toml` with a reason instead of adding ad hoc CI shell flags or skipping
+the mise task.
+
+`cargo-vet` is not a required local or CI gate yet. Future blocking vet
+adoption must first define audit ownership, exemption policy, and maintenance
+expectations in OpenSpec or contributor documentation.
+
+Release publishing workflows, crates.io token handling, and automated GitHub
+release creation are intentionally out of scope until a later usable-product
+milestone defines distribution readiness.
+
+## Rust tool behavior configuration
+
+Rust formatting and lint entrypoints remain `mise run fmt` and `mise run clippy`. This
+change does not add `rustfmt.toml` or `clippy.toml` because the current repository
+uses stable default behavior plus explicit mise commands; adding empty or
+duplicative config files would create another source of truth without reducing
+environment drift. Add either file only when a later change needs stable
+project-wide behavior that cannot be expressed by the existing mise tasks.
 
 ## OpenSpec-first workflow
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,11 @@
 [workspace]
 members = ["crates/oxmux", "crates/oxidemux"]
 resolver = "3"
+
+[workspace.package]
+edition = "2024"
+rust-version = "1.95.0"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/weshipwork/oxidemux"
+homepage = "https://github.com/weshipwork/oxidemux"
+authors = ["OxideMux contributors"]

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ native app while remaining testable through a shared headless core.
 - `rust-toolchain.toml`: Pinned Rust 1.95.0 toolchain.
 - `LICENSE-MIT` and `LICENSE-APACHE`: Dual-license files.
 - `.github/workflows/ci.yml`: Multi-platform verification workflow.
+- `.github/workflows/security.yml`: Mise-backed dependency policy and
+  vulnerability verification workflow.
+- `deny.toml`: Reviewable cargo-deny supply-chain policy for advisories,
+  licenses, duplicate dependencies, registries, and git sources.
 - `CONTRIBUTING.md`: Contributor setup, OpenSpec workflow, and PR hygiene
   guidance.
 - `CHANGELOG.md`: Notable project changes following Keep a Changelog format.
@@ -139,13 +143,22 @@ mise run hk-install
 
 # Run quality checks
 mise run ci
+mise run security
 mise run hk-check
 ```
 
-The `mise run ci` task runs workspace-wide formatting, checking, clippy, and
-tests across both `oxmux` and `oxidemux`. The `mise run hk-check` task runs the
-repository hook checks without requiring contributors to remember the underlying
-hk command.
+The `mise run ci` task runs workspace-wide formatting, checking, clippy,
+tests, and documentation checks across both `oxmux` and `oxidemux`. The
+`mise run security` task runs dependency policy and vulnerability checks through
+`mise run deny` and `mise run audit`; add any required advisory, license,
+duplicate dependency, registry, or git-source exceptions to `deny.toml` with a
+reviewable reason rather than bypassing them in CI shell commands. The
+`mise run hk-check` task runs the repository hook checks without requiring
+contributors to remember the underlying hk command.
+
+Release publishing workflows, crates.io token handling, automated GitHub release
+creation, and blocking `cargo-vet` gates are intentionally deferred until a
+later usable-product milestone defines distribution ownership and audit policy.
 
 See `CONTRIBUTING.md` for the OpenSpec-first development workflow, PR template
 expectations, and the reason CI uses the same mise task graph as local

--- a/crates/oxidemux/Cargo.toml
+++ b/crates/oxidemux/Cargo.toml
@@ -1,14 +1,21 @@
 [package]
 name = "oxidemux"
 version = "0.1.0"
-edition = "2024"
-rust-version = "1.95.0"
-license = "MIT OR Apache-2.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
 description = "A cross-platform Rust and GPUI-based AI subscription proxy shell inspired by VibeProxy."
+readme = "../../README.md"
+documentation = "https://docs.rs/oxidemux"
+keywords = ["ai", "proxy", "desktop", "subscription"]
+categories = ["development-tools"]
 
 [[bin]]
 name = "oxidemux"
 path = "src/main.rs"
 
 [dependencies]
-oxmux = { path = "../oxmux" }
+oxmux = { path = "../oxmux", version = "0.1.0" }

--- a/crates/oxmux/Cargo.toml
+++ b/crates/oxmux/Cargo.toml
@@ -1,10 +1,17 @@
 [package]
 name = "oxmux"
 version = "0.1.0"
-edition = "2024"
-rust-version = "1.95.0"
-license = "MIT OR Apache-2.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+authors.workspace = true
 description = "Headless reusable core boundary for OxideMux."
+readme = "../../README.md"
+documentation = "https://docs.rs/oxmux"
+keywords = ["ai", "proxy", "routing", "subscription"]
+categories = ["development-tools"]
 
 [lib]
 path = "src/oxmux.rs"

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,33 @@
+# Repository supply-chain policy for mise run deny.
+# Policy exceptions must be added here with a reason, not hidden in CI shell commands.
+
+[advisories]
+version = 2
+ignore = []
+
+[licenses]
+version = 2
+allow = [
+    "Apache-2.0",
+    "MIT",
+    "Unicode-3.0",
+]
+confidence-threshold = 0.8
+exceptions = []
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+workspace-default-features = "allow"
+external-default-features = "allow"
+allow = []
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/hk.pkl
+++ b/hk.pkl
@@ -127,6 +127,18 @@ local quality_steps = new Mapping<String, Step> {
         glob = List("*.rs", "Cargo.toml", "Cargo.lock")
         check = "scripts/quiet-on-success.sh cargo test --all-targets --all-features"
     }
+    ["mise-security"] {
+        glob = List(
+            "Cargo.toml",
+            "Cargo.lock",
+            "mise.toml",
+            "deny.toml",
+            "hk.pkl",
+            ".github/workflows/*.yml",
+            ".github/workflows/*.yaml",
+        )
+        check = "scripts/quiet-on-success.sh mise run security"
+    }
 }
 
 hooks {

--- a/hk.pkl
+++ b/hk.pkl
@@ -111,21 +111,15 @@ local quality_steps = new Mapping<String, Step> {
         exclude = generated_excludes
         check = "sh -c 'rumdl check --no-cache --diff README.md' sh"
     }
-    ["cargo-fmt"] {
-        glob = List("*.rs")
-        check = "scripts/quiet-on-success.sh cargo fmt --all -- --check"
-    }
-    ["cargo-check"] {
-        glob = List("*.rs", "Cargo.toml", "Cargo.lock")
-        check = "scripts/quiet-on-success.sh cargo check --all-targets --all-features"
-    }
-    ["cargo-clippy"] {
-        glob = List("*.rs", "Cargo.toml", "Cargo.lock")
-        check = "scripts/quiet-on-success.sh cargo clippy --all-targets --all-features -- -D warnings"
-    }
-    ["cargo-test"] {
-        glob = List("*.rs", "Cargo.toml", "Cargo.lock")
-        check = "scripts/quiet-on-success.sh cargo test --all-targets --all-features"
+    ["mise-ci"] {
+        glob = List(
+            "*.rs",
+            "Cargo.toml",
+            "Cargo.lock",
+            "mise.toml",
+            "rust-toolchain.toml",
+        )
+        check = "scripts/quiet-on-success.sh mise run ci"
     }
     ["mise-security"] {
         glob = List(
@@ -138,6 +132,10 @@ local quality_steps = new Mapping<String, Step> {
             ".github/workflows/*.yaml",
         )
         check = "scripts/quiet-on-success.sh mise run security"
+    }
+    ["openspec-validate"] {
+        glob = List("openspec/**/*.md", "openspec/**/*.yaml", "openspec/**/*.yml")
+        check = "scripts/quiet-on-success.sh openspec validate --all --strict"
     }
 }
 

--- a/hk.pkl
+++ b/hk.pkl
@@ -135,7 +135,7 @@ local quality_steps = new Mapping<String, Step> {
     }
     ["openspec-validate"] {
         glob = List("openspec/**/*.md", "openspec/**/*.yaml", "openspec/**/*.yml")
-        check = "scripts/quiet-on-success.sh openspec validate --all --strict"
+        check = "scripts/quiet-on-success.sh mise run openspec-validate-all"
     }
 }
 

--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,8 @@ pkl = "latest"
 typos = "1.45.2"
 gitleaks = "latest"
 rumdl = "latest"
+"cargo:cargo-deny" = "0.19.0"
+"cargo:cargo-audit" = "0.22.1"
 
 [tasks.rust-components]
 run = "rustup component add rustfmt clippy --toolchain 1.95.0"
@@ -27,6 +29,18 @@ run = "cargo test --all-targets --all-features"
 [tasks.doc]
 env = { RUSTDOCFLAGS = "-D warnings" }
 run = "cargo doc --workspace --no-deps"
+
+[tasks.deny]
+run = "cargo deny --workspace check advisories bans licenses sources"
+
+[tasks.audit]
+run = "cargo audit --deny warnings"
+
+[tasks.security]
+run = [
+    "mise run deny",
+    "mise run audit",
+]
 
 [tasks.hk-check]
 run = "hk check --all"

--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,7 @@ pkl = "latest"
 typos = "1.45.2"
 gitleaks = "latest"
 rumdl = "latest"
+"npm:openspec" = "0.0.0"
 "cargo:cargo-deny" = "0.19.0"
 "cargo:cargo-audit" = "0.22.1"
 

--- a/mise.toml
+++ b/mise.toml
@@ -5,7 +5,7 @@ pkl = "latest"
 typos = "1.45.2"
 gitleaks = "latest"
 rumdl = "latest"
-"npm:openspec" = "0.0.0"
+"npm:@fission-ai/openspec" = "1.3.1"
 "cargo:cargo-deny" = "0.19.0"
 "cargo:cargo-audit" = "0.22.1"
 
@@ -56,7 +56,7 @@ run = "hk run pre-commit"
 run = "scripts/ci/validate-openspec-pr.sh"
 
 [tasks.openspec-validate-all]
-run = "mise exec npm:openspec@0.0.0 -- openspec validate --all --strict"
+run = "mise exec npm:@fission-ai/openspec@1.3.1 -- openspec validate --all --strict"
 
 [tasks.ci]
 run = [

--- a/mise.toml
+++ b/mise.toml
@@ -55,6 +55,9 @@ run = "hk run pre-commit"
 [tasks.openspec-validate]
 run = "scripts/ci/validate-openspec-pr.sh"
 
+[tasks.openspec-validate-all]
+run = "mise exec npm:openspec@0.0.0 -- openspec validate --all --strict"
+
 [tasks.ci]
 run = [
     "mise run rust-components",

--- a/openspec/changes/adopt-production-readiness-workflow/.openspec.yaml
+++ b/openspec/changes/adopt-production-readiness-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/adopt-production-readiness-workflow/design.md
+++ b/openspec/changes/adopt-production-readiness-workflow/design.md
@@ -1,0 +1,83 @@
+## Context
+
+OxideMux already treats `mise.toml` as the canonical local and CI task graph. The current workflow runs formatting, checking, clippy, tests, rustdoc, hk checks, and OpenSpec PR evidence validation through mise-backed GitHub Actions. Issue #35 expands the same repository workflow layer to cover production-readiness patterns from `langfuse-rs`: security checks, supply-chain policy, and package metadata.
+
+The important constraint is that `langfuse-rs` is a reference, not a template. Its security and release workflows prove the desired shape, but OxideMux must keep tool installation and command selection centralized in mise. Release publishing and release workflow scaffolding are intentionally deferred until OxideMux has usable product behavior and a clear distribution milestone.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a mise-defined security workflow that can run locally and in GitHub Actions.
+- Add initial `cargo-deny` policy and `cargo-audit` vulnerability checks.
+- Keep `cargo-vet` evaluated but non-blocking until audits and exemptions are maintainable.
+- Centralize shared Cargo package metadata without changing package behavior.
+- Prepare crate manifests for future distribution metadata review.
+- Add explicit Rust tool behavior configuration only when it reduces drift from mise-managed checks.
+- Document the new security workflow for contributors.
+
+**Non-Goals:**
+
+- No release publishing workflow.
+- No crates.io publishing, token handling, or release automation.
+- No changelog-derived GitHub release creation.
+- No changes to `oxmux` runtime semantics, `oxidemux` app-shell behavior, provider execution, routing, protocol translation, subscription UX, or GPUI behavior.
+- No blocking `cargo-vet` gate unless a later proposal defines audit ownership and exemption maintenance.
+
+## Decisions
+
+### Decision: Make mise the security command boundary
+
+Security tools should be installed or pinned through `mise.toml` where practical, and GitHub Actions should call mise tasks such as `mise run security`, `mise run audit`, or `mise run deny`. Workflow YAML must not install `cargo-deny` or `cargo-audit` directly with raw cargo commands, and it must not run the underlying cargo security tools directly when a mise task exists.
+
+Alternative considered: copy `langfuse-rs` workflow steps that install cargo tools directly in Actions. Rejected because OxideMux already specifies mise as the workflow source of truth, and duplicated setup would drift from local verification.
+
+### Decision: Add `cargo-deny` and `cargo-audit` first
+
+`cargo-deny` gives an immediate policy surface for licenses, duplicate crates, advisories, registries, and git sources. `cargo-audit` gives a focused vulnerability check that is easy for contributors to understand and run locally.
+
+Alternative considered: start with `cargo-vet` as the primary supply-chain gate. Rejected for this change because `cargo-vet` requires an audit/exemption maintenance model that is premature for the current small dependency graph.
+
+### Decision: Treat `cargo-vet` as deferred evaluation
+
+This change may add documentation or a task placeholder for evaluating `cargo-vet`, but it must not make vetting a required CI gate unless the dependency graph, exemption policy, and ownership model are established.
+
+Alternative considered: add a generated `supply-chain/config.toml` immediately. Rejected unless the implementation can prove it is maintainable and non-blocking; otherwise it creates security theater and future churn.
+
+### Decision: Centralize shared metadata with workspace inheritance
+
+The root workspace manifest should own shared fields such as edition, rust-version, license, repository, homepage, and authors where applicable. Crate manifests should inherit shared metadata and keep crate-specific metadata local.
+
+Alternative considered: leave metadata duplicated in crate manifests. Rejected because duplicated package metadata drifts before distribution and makes future publishing review harder.
+
+### Decision: Defer release automation entirely
+
+Issue #35 originally mentioned release workflow scaffolding, but OxideMux is not usable yet. Release automation would introduce publishing assumptions before crate ownership, binary packaging, versioning, and product readiness are settled.
+
+Alternative considered: add a no-publish release workflow that only runs CI and extracts changelog notes. Rejected for this proposal because even scaffolded release automation invites premature maintenance and should be revisited at a usable-product milestone.
+
+## Risks / Trade-offs
+
+- `cargo-deny` license policy could block acceptable transitive dependencies. Mitigation: start with an explicit, reviewable allow list aligned with current dependencies and document how exceptions are reviewed.
+- Duplicate dependency checks can be noisy while dependencies are still evolving. Mitigation: use warning levels where appropriate and reserve hard failures for policy violations that are clearly actionable.
+- `cargo-audit` can fail on advisories without available fixes. Mitigation: document how ignored advisories must be justified in policy rather than silently bypassed.
+- Workspace metadata inheritance can accidentally change package metadata. Mitigation: verify `cargo metadata`/manifest behavior and keep crate-specific fields local when inheritance would alter package identity.
+- Adding tool config files can create another source of truth. Mitigation: only add `clippy.toml` or `rustfmt.toml` when they express stable behavior not already captured by mise commands.
+
+## Migration Plan
+
+1. Add the development-workflow spec updates for security verification, supply-chain policy, metadata readiness, and release automation deferral.
+2. Add mise tool pins and security tasks.
+3. Add `deny.toml` and wire `cargo-deny`/`cargo-audit` through mise.
+4. Add a dedicated GitHub security workflow that sets up mise and runs the mise security task.
+5. Centralize workspace package metadata and update crate manifests.
+6. Update README/CONTRIBUTING/PR guidance for the new security checks and release deferral.
+7. Verify `mise run ci`, `mise run hk-check`, and the new security task.
+
+Rollback is straightforward because this change is repository tooling and metadata only: remove the new workflow/config/tasks and restore manifest metadata if any check creates unacceptable churn.
+
+## Open Questions
+
+- Which exact `cargo-deny` license allow list should be used for the current dependency graph?
+- Should duplicate dependencies be warnings or hard failures at first adoption?
+- Which mise backend is most reliable for pinning `cargo-deny` and `cargo-audit` in local and CI environments while still keeping workflow YAML limited to mise setup plus `mise run ...` invocations?

--- a/openspec/changes/adopt-production-readiness-workflow/proposal.md
+++ b/openspec/changes/adopt-production-readiness-workflow/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+OxideMux has a mise-first development workflow, but it does not yet expose repository-level security checks, supply-chain policy, or distribution-ready Cargo metadata through that workflow. Issue #35 asks us to adopt the production-readiness patterns proven in `langfuse-rs` while preserving `mise.toml` as the local and CI source of truth.
+
+## What Changes
+
+- Add repository security verification as a first-class mise-defined workflow, including local and GitHub Actions entrypoints.
+- Add initial supply-chain policy for `cargo-deny`, covering vulnerability advisories, license allowances, duplicate dependencies, registries, and git sources.
+- Add `cargo-audit` as a mise-managed vulnerability check.
+- Defer blocking `cargo-vet` adoption until the dependency graph and audit/exemption policy are stable enough to maintain.
+- Centralize shared Cargo package metadata in the workspace manifest with `[workspace.package]` and use workspace inheritance where appropriate.
+- Add crate/package metadata needed before future distribution, such as repository, readme, documentation, keywords, categories, and package exclusions.
+- Add explicit `clippy.toml` and `rustfmt.toml` only where they reduce environment drift and complement existing mise tasks.
+- Update contributor documentation so local security checks are run through `mise run ...`, not raw cargo tool invocations.
+- Exclude release publishing, release workflow scaffolding, crates.io token handling, and changelog-derived GitHub releases from this change until OxideMux is usable.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- No new product/runtime capabilities. -->
+
+### Modified Capabilities
+
+- `development-workflow`: Extend the repository workflow contract to include mise-defined security checks, supply-chain policy, Cargo metadata readiness, and explicit release automation deferral.
+
+## Impact
+
+- Affects repository workflow files such as `mise.toml`, `.github/workflows/`, `deny.toml`, optional tool config files, `Cargo.toml`, crate manifests, README, and contributor documentation.
+- Does not change `oxmux` runtime behavior, `oxidemux` app behavior, public Rust API semantics, provider execution, routing, protocol translation, subscription UX, or GPUI behavior.
+- Keeps `mise run ci` as the existing quality gate and adds security verification beside it rather than expanding release automation prematurely.

--- a/openspec/changes/adopt-production-readiness-workflow/specs/development-workflow/spec.md
+++ b/openspec/changes/adopt-production-readiness-workflow/specs/development-workflow/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Mise defines repository security verification
+The repository SHALL expose supply-chain and vulnerability checks through mise-defined tasks that can be run locally and from GitHub Actions.
+
+#### Scenario: Local security verification uses mise
+- **WHEN** a contributor reads the development workflow documentation
+- **THEN** it tells them to run repository security verification through `mise run security` or documented granular mise tasks
+
+#### Scenario: Security CI invokes mise verification
+- **WHEN** GitHub Actions runs repository security checks
+- **THEN** the workflow sets up mise tooling and invokes mise-defined security tasks instead of installing or running cargo security tools directly in workflow YAML
+
+#### Scenario: Security workflow covers routine triggers
+- **WHEN** maintainers inspect the security workflow triggers
+- **THEN** the workflow runs for pull requests, pushes to `main`, and scheduled checks
+
+#### Scenario: Security task preserves standard CI
+- **WHEN** maintainers add security verification tasks
+- **THEN** the existing `mise run ci` quality contract continues to run formatting, checking, clippy, tests, and documentation checks without being replaced by security-only checks
+
+### Requirement: Supply-chain policy is explicit and reviewable
+The repository SHALL include an initial supply-chain policy for Rust dependencies that covers vulnerability advisories, license allowances, duplicate dependency handling, registries, and git sources.
+
+#### Scenario: Cargo deny policy is present
+- **WHEN** a contributor runs the documented supply-chain policy check
+- **THEN** the check evaluates a repository `deny.toml` policy for advisories, licenses, duplicate crates, registries, and git sources
+
+#### Scenario: Unknown dependency sources are rejected
+- **WHEN** dependency resolution includes an unapproved registry or git source
+- **THEN** the supply-chain policy check fails with a clear source policy violation
+
+#### Scenario: Policy exceptions stay visible
+- **WHEN** a dependency requires a license, advisory, duplicate, registry, or git-source exception
+- **THEN** the exception is recorded in the repository policy instead of being hidden in ad hoc CI commands
+
+### Requirement: Cargo vet remains deferred until maintainable
+The repository SHALL NOT require `cargo-vet` as a blocking local or CI gate until a later change defines audit ownership, exemption policy, and maintenance expectations.
+
+#### Scenario: Cargo vet is not required by initial security verification
+- **WHEN** a contributor runs the initial documented security verification for this change
+- **THEN** it does not fail solely because `cargo-vet` audits or exemptions have not been initialized
+
+#### Scenario: Cargo vet is non-blocking in CI
+- **WHEN** GitHub Actions runs the initial security workflow for this change
+- **THEN** `cargo-vet` is absent from the required path or is explicitly configured as non-blocking
+
+#### Scenario: Future cargo vet adoption requires policy
+- **WHEN** maintainers decide to make `cargo-vet` blocking
+- **THEN** they first define the audit ownership and exemption policy in OpenSpec or contributor documentation
+
+### Requirement: Cargo workspace metadata is centralized for future distribution
+The repository SHALL centralize shared Cargo package metadata in the workspace manifest and use workspace inheritance where it does not change crate behavior.
+
+#### Scenario: Shared package metadata is inherited
+- **WHEN** maintainers inspect workspace and crate manifests
+- **THEN** shared metadata such as edition, rust-version, license, repository, homepage, and authors is defined once in `[workspace.package]` where appropriate and inherited by workspace crates
+
+#### Scenario: Crate-specific metadata remains local
+- **WHEN** a crate needs package-specific metadata such as name, description, readme, documentation, keywords, categories, or exclusions
+- **THEN** that metadata remains in the crate manifest or explicitly inherits only fields that preserve the crate's package identity
+
+#### Scenario: Metadata changes do not alter runtime behavior
+- **WHEN** workspace package metadata is centralized
+- **THEN** `oxmux` and `oxidemux` runtime behavior, public API semantics, and crate boundary responsibilities remain unchanged
+
+#### Scenario: Metadata changes preserve package identity
+- **WHEN** workspace package metadata and crate metadata are updated
+- **THEN** manifest validation confirms package names, crate targets, readme/documentation links, included files, and package-specific descriptions remain intentional without requiring release publishing
+
+### Requirement: Rust tool configuration remains subordinate to mise tasks
+The repository SHALL add explicit Rust tool configuration files only when they complement mise-defined checks and reduce environment drift.
+
+#### Scenario: Clippy configuration complements mise
+- **WHEN** maintainers add or update `clippy.toml`
+- **THEN** the configuration captures stable project-wide lint behavior without replacing `mise run clippy` as the contributor and CI entrypoint
+
+#### Scenario: Rustfmt configuration complements mise
+- **WHEN** maintainers add or update `rustfmt.toml`
+- **THEN** the configuration captures stable project-wide formatting behavior without replacing `mise run fmt` as the contributor and CI entrypoint
+
+#### Scenario: Tool configuration is omitted when redundant
+- **WHEN** explicit Rust tool configuration would only duplicate existing defaults or mise task commands
+- **THEN** the implementation omits that configuration and documents why no file was added
+
+### Requirement: Release automation is deferred until usable product readiness
+The repository SHALL defer release publishing workflows, crates.io token handling, and automated GitHub release creation until OxideMux has a usable product milestone and a separate release proposal.
+
+#### Scenario: Production-readiness workflow excludes publishing
+- **WHEN** this change is implemented
+- **THEN** it does not add a release publishing workflow, crates.io publishing steps, or required publishing credentials
+
+#### Scenario: Release readiness is documented as deferred
+- **WHEN** contributors read workflow documentation after this change
+- **THEN** it explains that release automation is intentionally deferred until a later usable-product milestone

--- a/openspec/changes/adopt-production-readiness-workflow/tasks.md
+++ b/openspec/changes/adopt-production-readiness-workflow/tasks.md
@@ -1,0 +1,52 @@
+## 1. Mise-managed security tooling
+
+- [x] 1.1 Add mise-managed tool pins or installation strategy for `cargo-deny` and `cargo-audit`.
+- [x] 1.2 Add granular mise tasks for dependency policy and vulnerability checks.
+- [x] 1.3 Add a top-level `mise run security` task that runs the granular security checks.
+- [x] 1.4 Verify the new security tasks do not replace or weaken the existing `mise run ci` task.
+- [x] 1.5 Verify GitHub workflow YAML does not install or run `cargo-deny`, `cargo-audit`, or other cargo security tools directly when a mise task exists.
+
+## 2. Supply-chain policy
+
+- [x] 2.1 Add an initial `deny.toml` covering advisories, license allow list, duplicate dependency handling, registries, and git sources.
+- [x] 2.2 Run the cargo-deny task and tune only explicit, reviewable policy exceptions required by the current dependency graph.
+- [x] 2.3 Run the cargo-audit task and document any unavoidable advisory exceptions in policy rather than CI shell commands.
+- [x] 2.4 Document that blocking `cargo-vet` adoption is deferred pending audit ownership and exemption policy.
+- [x] 2.5 Verify `cargo-vet` is absent from required local and CI security paths or explicitly non-blocking.
+
+## 3. GitHub security workflow
+
+- [x] 3.1 Add a dedicated GitHub Actions security workflow for pull requests, pushes to `main`, and scheduled checks.
+- [x] 3.2 Configure the workflow to set up mise and invoke `mise run security` instead of duplicating raw cargo security commands.
+- [x] 3.3 Keep workflow permissions minimal and read-only unless a later change requires elevated permissions.
+
+## 4. Cargo metadata readiness
+
+- [x] 4.1 Add shared `[workspace.package]` metadata to the root `Cargo.toml` where inheritance preserves current package behavior.
+- [x] 4.2 Update `crates/oxmux/Cargo.toml` to inherit shared metadata and keep crate-specific package metadata local.
+- [x] 4.3 Update `crates/oxidemux/Cargo.toml` to inherit shared metadata and keep crate-specific package metadata local.
+- [x] 4.4 Add distribution-readiness metadata such as repository, readme, documentation, keywords, categories, and package exclusions where appropriate.
+- [x] 4.5 Verify manifest metadata changes preserve package names, crate targets, readme/documentation links, included files, package-specific descriptions, runtime behavior, and crate boundary responsibilities without requiring release publishing.
+
+## 5. Tool behavior configuration
+
+- [x] 5.1 Evaluate whether `clippy.toml` reduces drift beyond the existing `mise run clippy` command.
+- [x] 5.2 Add `clippy.toml` only if it captures stable project-wide lint behavior.
+- [x] 5.3 Evaluate whether `rustfmt.toml` reduces drift beyond the existing `mise run fmt` command.
+- [x] 5.4 Add `rustfmt.toml` only if it captures stable project-wide formatting behavior.
+
+## 6. Documentation and scope guardrails
+
+- [x] 6.1 Update README development instructions to include the new mise security task.
+- [x] 6.2 Update `CONTRIBUTING.md` to explain security verification, supply-chain policy exceptions, and deferred release automation.
+- [x] 6.3 Update the pull request template if needed so contributors can report security verification results.
+- [x] 6.4 Ensure documentation states that release publishing workflows, crates.io token handling, and automated GitHub releases remain out of scope until a later usable-product milestone.
+
+## 7. Verification
+
+- [x] 7.1 Run `openspec validate adopt-production-readiness-workflow --strict`.
+- [x] 7.2 Run `mise run security` or the new granular security task set.
+- [x] 7.3 Run `mise run ci`.
+- [x] 7.4 Run `mise run hk-check`.
+- [x] 7.5 Confirm no release workflow or publishing credential requirement was introduced.
+- [x] 7.6 Confirm `cargo-vet` is not required for local or CI success in this change.

--- a/openspec/changes/archive/2026-04-29-adopt-production-readiness-workflow/.openspec.yaml
+++ b/openspec/changes/archive/2026-04-29-adopt-production-readiness-workflow/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-29

--- a/openspec/changes/archive/2026-04-29-adopt-production-readiness-workflow/design.md
+++ b/openspec/changes/archive/2026-04-29-adopt-production-readiness-workflow/design.md
@@ -1,0 +1,83 @@
+## Context
+
+OxideMux already treats `mise.toml` as the canonical local and CI task graph. The current workflow runs formatting, checking, clippy, tests, rustdoc, hk checks, and OpenSpec PR evidence validation through mise-backed GitHub Actions. Issue #35 expands the same repository workflow layer to cover production-readiness patterns from `langfuse-rs`: security checks, supply-chain policy, and package metadata.
+
+The important constraint is that `langfuse-rs` is a reference, not a template. Its security and release workflows prove the desired shape, but OxideMux must keep tool installation and command selection centralized in mise. Release publishing and release workflow scaffolding are intentionally deferred until OxideMux has usable product behavior and a clear distribution milestone.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Add a mise-defined security workflow that can run locally and in GitHub Actions.
+- Add initial `cargo-deny` policy and `cargo-audit` vulnerability checks.
+- Keep `cargo-vet` evaluated but non-blocking until audits and exemptions are maintainable.
+- Centralize shared Cargo package metadata without changing package behavior.
+- Prepare crate manifests for future distribution metadata review.
+- Add explicit Rust tool behavior configuration only when it reduces drift from mise-managed checks.
+- Document the new security workflow for contributors.
+
+**Non-Goals:**
+
+- No release publishing workflow.
+- No crates.io publishing, token handling, or release automation.
+- No changelog-derived GitHub release creation.
+- No changes to `oxmux` runtime semantics, `oxidemux` app-shell behavior, provider execution, routing, protocol translation, subscription UX, or GPUI behavior.
+- No blocking `cargo-vet` gate unless a later proposal defines audit ownership and exemption maintenance.
+
+## Decisions
+
+### Decision: Make mise the security command boundary
+
+Security tools should be installed or pinned through `mise.toml` where practical, and GitHub Actions should call mise tasks such as `mise run security`, `mise run audit`, or `mise run deny`. Workflow YAML must not install `cargo-deny` or `cargo-audit` directly with raw cargo commands, and it must not run the underlying cargo security tools directly when a mise task exists.
+
+Alternative considered: copy `langfuse-rs` workflow steps that install cargo tools directly in Actions. Rejected because OxideMux already specifies mise as the workflow source of truth, and duplicated setup would drift from local verification.
+
+### Decision: Add `cargo-deny` and `cargo-audit` first
+
+`cargo-deny` gives an immediate policy surface for licenses, duplicate crates, advisories, registries, and git sources. `cargo-audit` gives a focused vulnerability check that is easy for contributors to understand and run locally.
+
+Alternative considered: start with `cargo-vet` as the primary supply-chain gate. Rejected for this change because `cargo-vet` requires an audit/exemption maintenance model that is premature for the current small dependency graph.
+
+### Decision: Treat `cargo-vet` as deferred evaluation
+
+This change may add documentation or a task placeholder for evaluating `cargo-vet`, but it must not make vetting a required CI gate unless the dependency graph, exemption policy, and ownership model are established.
+
+Alternative considered: add a generated `supply-chain/config.toml` immediately. Rejected unless the implementation can prove it is maintainable and non-blocking; otherwise it creates security theater and future churn.
+
+### Decision: Centralize shared metadata with workspace inheritance
+
+The root workspace manifest should own shared fields such as edition, rust-version, license, repository, homepage, and authors where applicable. Crate manifests should inherit shared metadata and keep crate-specific metadata local.
+
+Alternative considered: leave metadata duplicated in crate manifests. Rejected because duplicated package metadata drifts before distribution and makes future publishing review harder.
+
+### Decision: Defer release automation entirely
+
+Issue #35 originally mentioned release workflow scaffolding, but OxideMux is not usable yet. Release automation would introduce publishing assumptions before crate ownership, binary packaging, versioning, and product readiness are settled.
+
+Alternative considered: add a no-publish release workflow that only runs CI and extracts changelog notes. Rejected for this proposal because even scaffolded release automation invites premature maintenance and should be revisited at a usable-product milestone.
+
+## Risks / Trade-offs
+
+- `cargo-deny` license policy could block acceptable transitive dependencies. Mitigation: start with an explicit, reviewable allow list aligned with current dependencies and document how exceptions are reviewed.
+- Duplicate dependency checks can be noisy while dependencies are still evolving. Mitigation: use warning levels where appropriate and reserve hard failures for policy violations that are clearly actionable.
+- `cargo-audit` can fail on advisories without available fixes. Mitigation: document how ignored advisories must be justified in policy rather than silently bypassed.
+- Workspace metadata inheritance can accidentally change package metadata. Mitigation: verify `cargo metadata`/manifest behavior and keep crate-specific fields local when inheritance would alter package identity.
+- Adding tool config files can create another source of truth. Mitigation: only add `clippy.toml` or `rustfmt.toml` when they express stable behavior not already captured by mise commands.
+
+## Migration Plan
+
+1. Add the development-workflow spec updates for security verification, supply-chain policy, metadata readiness, and release automation deferral.
+2. Add mise tool pins and security tasks.
+3. Add `deny.toml` and wire `cargo-deny`/`cargo-audit` through mise.
+4. Add a dedicated GitHub security workflow that sets up mise and runs the mise security task.
+5. Centralize workspace package metadata and update crate manifests.
+6. Update README/CONTRIBUTING/PR guidance for the new security checks and release deferral.
+7. Verify `mise run ci`, `mise run hk-check`, and the new security task.
+
+Rollback is straightforward because this change is repository tooling and metadata only: remove the new workflow/config/tasks and restore manifest metadata if any check creates unacceptable churn.
+
+## Open Questions
+
+- Which exact `cargo-deny` license allow list should be used for the current dependency graph?
+- Should duplicate dependencies be warnings or hard failures at first adoption?
+- Which mise backend is most reliable for pinning `cargo-deny` and `cargo-audit` in local and CI environments while still keeping workflow YAML limited to mise setup plus `mise run ...` invocations?

--- a/openspec/changes/archive/2026-04-29-adopt-production-readiness-workflow/proposal.md
+++ b/openspec/changes/archive/2026-04-29-adopt-production-readiness-workflow/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+OxideMux has a mise-first development workflow, but it does not yet expose repository-level security checks, supply-chain policy, or distribution-ready Cargo metadata through that workflow. Issue #35 asks us to adopt the production-readiness patterns proven in `langfuse-rs` while preserving `mise.toml` as the local and CI source of truth.
+
+## What Changes
+
+- Add repository security verification as a first-class mise-defined workflow, including local and GitHub Actions entrypoints.
+- Add initial supply-chain policy for `cargo-deny`, covering vulnerability advisories, license allowances, duplicate dependencies, registries, and git sources.
+- Add `cargo-audit` as a mise-managed vulnerability check.
+- Defer blocking `cargo-vet` adoption until the dependency graph and audit/exemption policy are stable enough to maintain.
+- Centralize shared Cargo package metadata in the workspace manifest with `[workspace.package]` and use workspace inheritance where appropriate.
+- Add crate/package metadata needed before future distribution, such as repository, readme, documentation, keywords, categories, and package exclusions.
+- Add explicit `clippy.toml` and `rustfmt.toml` only where they reduce environment drift and complement existing mise tasks.
+- Update contributor documentation so local security checks are run through `mise run ...`, not raw cargo tool invocations.
+- Exclude release publishing, release workflow scaffolding, crates.io token handling, and changelog-derived GitHub releases from this change until OxideMux is usable.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- No new product/runtime capabilities. -->
+
+### Modified Capabilities
+
+- `development-workflow`: Extend the repository workflow contract to include mise-defined security checks, supply-chain policy, Cargo metadata readiness, and explicit release automation deferral.
+
+## Impact
+
+- Affects repository workflow files such as `mise.toml`, `.github/workflows/`, `deny.toml`, optional tool config files, `Cargo.toml`, crate manifests, README, and contributor documentation.
+- Does not change `oxmux` runtime behavior, `oxidemux` app behavior, public Rust API semantics, provider execution, routing, protocol translation, subscription UX, or GPUI behavior.
+- Keeps `mise run ci` as the existing quality gate and adds security verification beside it rather than expanding release automation prematurely.

--- a/openspec/changes/archive/2026-04-29-adopt-production-readiness-workflow/specs/development-workflow/spec.md
+++ b/openspec/changes/archive/2026-04-29-adopt-production-readiness-workflow/specs/development-workflow/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: Mise defines repository security verification
+The repository SHALL expose supply-chain and vulnerability checks through mise-defined tasks that can be run locally and from GitHub Actions.
+
+#### Scenario: Local security verification uses mise
+- **WHEN** a contributor reads the development workflow documentation
+- **THEN** it tells them to run repository security verification through `mise run security` or documented granular mise tasks
+
+#### Scenario: Security CI invokes mise verification
+- **WHEN** GitHub Actions runs repository security checks
+- **THEN** the workflow sets up mise tooling and invokes mise-defined security tasks instead of installing or running cargo security tools directly in workflow YAML
+
+#### Scenario: Security workflow covers routine triggers
+- **WHEN** maintainers inspect the security workflow triggers
+- **THEN** the workflow runs for pull requests, pushes to `main`, and scheduled checks
+
+#### Scenario: Security task preserves standard CI
+- **WHEN** maintainers add security verification tasks
+- **THEN** the existing `mise run ci` quality contract continues to run formatting, checking, clippy, tests, and documentation checks without being replaced by security-only checks
+
+### Requirement: Supply-chain policy is explicit and reviewable
+The repository SHALL include an initial supply-chain policy for Rust dependencies that covers vulnerability advisories, license allowances, duplicate dependency handling, registries, and git sources.
+
+#### Scenario: Cargo deny policy is present
+- **WHEN** a contributor runs the documented supply-chain policy check
+- **THEN** the check evaluates a repository `deny.toml` policy for advisories, licenses, duplicate crates, registries, and git sources
+
+#### Scenario: Unknown dependency sources are rejected
+- **WHEN** dependency resolution includes an unapproved registry or git source
+- **THEN** the supply-chain policy check fails with a clear source policy violation
+
+#### Scenario: Policy exceptions stay visible
+- **WHEN** a dependency requires a license, advisory, duplicate, registry, or git-source exception
+- **THEN** the exception is recorded in the repository policy instead of being hidden in ad hoc CI commands
+
+### Requirement: Cargo vet remains deferred until maintainable
+The repository SHALL NOT require `cargo-vet` as a blocking local or CI gate until a later change defines audit ownership, exemption policy, and maintenance expectations.
+
+#### Scenario: Cargo vet is not required by initial security verification
+- **WHEN** a contributor runs the initial documented security verification for this change
+- **THEN** it does not fail solely because `cargo-vet` audits or exemptions have not been initialized
+
+#### Scenario: Cargo vet is non-blocking in CI
+- **WHEN** GitHub Actions runs the initial security workflow for this change
+- **THEN** `cargo-vet` is absent from the required path or is explicitly configured as non-blocking
+
+#### Scenario: Future cargo vet adoption requires policy
+- **WHEN** maintainers decide to make `cargo-vet` blocking
+- **THEN** they first define the audit ownership and exemption policy in OpenSpec or contributor documentation
+
+### Requirement: Cargo workspace metadata is centralized for future distribution
+The repository SHALL centralize shared Cargo package metadata in the workspace manifest and use workspace inheritance where it does not change crate behavior.
+
+#### Scenario: Shared package metadata is inherited
+- **WHEN** maintainers inspect workspace and crate manifests
+- **THEN** shared metadata such as edition, rust-version, license, repository, homepage, and authors is defined once in `[workspace.package]` where appropriate and inherited by workspace crates
+
+#### Scenario: Crate-specific metadata remains local
+- **WHEN** a crate needs package-specific metadata such as name, description, readme, documentation, keywords, categories, or exclusions
+- **THEN** that metadata remains in the crate manifest or explicitly inherits only fields that preserve the crate's package identity
+
+#### Scenario: Metadata changes do not alter runtime behavior
+- **WHEN** workspace package metadata is centralized
+- **THEN** `oxmux` and `oxidemux` runtime behavior, public API semantics, and crate boundary responsibilities remain unchanged
+
+#### Scenario: Metadata changes preserve package identity
+- **WHEN** workspace package metadata and crate metadata are updated
+- **THEN** manifest validation confirms package names, crate targets, readme/documentation links, included files, and package-specific descriptions remain intentional without requiring release publishing
+
+### Requirement: Rust tool configuration remains subordinate to mise tasks
+The repository SHALL add explicit Rust tool configuration files only when they complement mise-defined checks and reduce environment drift.
+
+#### Scenario: Clippy configuration complements mise
+- **WHEN** maintainers add or update `clippy.toml`
+- **THEN** the configuration captures stable project-wide lint behavior without replacing `mise run clippy` as the contributor and CI entrypoint
+
+#### Scenario: Rustfmt configuration complements mise
+- **WHEN** maintainers add or update `rustfmt.toml`
+- **THEN** the configuration captures stable project-wide formatting behavior without replacing `mise run fmt` as the contributor and CI entrypoint
+
+#### Scenario: Tool configuration is omitted when redundant
+- **WHEN** explicit Rust tool configuration would only duplicate existing defaults or mise task commands
+- **THEN** the implementation omits that configuration and documents why no file was added
+
+### Requirement: Release automation is deferred until usable product readiness
+The repository SHALL defer release publishing workflows, crates.io token handling, and automated GitHub release creation until OxideMux has a usable product milestone and a separate release proposal.
+
+#### Scenario: Production-readiness workflow excludes publishing
+- **WHEN** this change is implemented
+- **THEN** it does not add a release publishing workflow, crates.io publishing steps, or required publishing credentials
+
+#### Scenario: Release readiness is documented as deferred
+- **WHEN** contributors read workflow documentation after this change
+- **THEN** it explains that release automation is intentionally deferred until a later usable-product milestone

--- a/openspec/changes/archive/2026-04-29-adopt-production-readiness-workflow/tasks.md
+++ b/openspec/changes/archive/2026-04-29-adopt-production-readiness-workflow/tasks.md
@@ -1,0 +1,52 @@
+## 1. Mise-managed security tooling
+
+- [x] 1.1 Add mise-managed tool pins or installation strategy for `cargo-deny` and `cargo-audit`.
+- [x] 1.2 Add granular mise tasks for dependency policy and vulnerability checks.
+- [x] 1.3 Add a top-level `mise run security` task that runs the granular security checks.
+- [x] 1.4 Verify the new security tasks do not replace or weaken the existing `mise run ci` task.
+- [x] 1.5 Verify GitHub workflow YAML does not install or run `cargo-deny`, `cargo-audit`, or other cargo security tools directly when a mise task exists.
+
+## 2. Supply-chain policy
+
+- [x] 2.1 Add an initial `deny.toml` covering advisories, license allow list, duplicate dependency handling, registries, and git sources.
+- [x] 2.2 Run the cargo-deny task and tune only explicit, reviewable policy exceptions required by the current dependency graph.
+- [x] 2.3 Run the cargo-audit task and document any unavoidable advisory exceptions in policy rather than CI shell commands.
+- [x] 2.4 Document that blocking `cargo-vet` adoption is deferred pending audit ownership and exemption policy.
+- [x] 2.5 Verify `cargo-vet` is absent from required local and CI security paths or explicitly non-blocking.
+
+## 3. GitHub security workflow
+
+- [x] 3.1 Add a dedicated GitHub Actions security workflow for pull requests, pushes to `main`, and scheduled checks.
+- [x] 3.2 Configure the workflow to set up mise and invoke `mise run security` instead of duplicating raw cargo security commands.
+- [x] 3.3 Keep workflow permissions minimal and read-only unless a later change requires elevated permissions.
+
+## 4. Cargo metadata readiness
+
+- [x] 4.1 Add shared `[workspace.package]` metadata to the root `Cargo.toml` where inheritance preserves current package behavior.
+- [x] 4.2 Update `crates/oxmux/Cargo.toml` to inherit shared metadata and keep crate-specific package metadata local.
+- [x] 4.3 Update `crates/oxidemux/Cargo.toml` to inherit shared metadata and keep crate-specific package metadata local.
+- [x] 4.4 Add distribution-readiness metadata such as repository, readme, documentation, keywords, categories, and package exclusions where appropriate.
+- [x] 4.5 Verify manifest metadata changes preserve package names, crate targets, readme/documentation links, included files, package-specific descriptions, runtime behavior, and crate boundary responsibilities without requiring release publishing.
+
+## 5. Tool behavior configuration
+
+- [x] 5.1 Evaluate whether `clippy.toml` reduces drift beyond the existing `mise run clippy` command.
+- [x] 5.2 Add `clippy.toml` only if it captures stable project-wide lint behavior.
+- [x] 5.3 Evaluate whether `rustfmt.toml` reduces drift beyond the existing `mise run fmt` command.
+- [x] 5.4 Add `rustfmt.toml` only if it captures stable project-wide formatting behavior.
+
+## 6. Documentation and scope guardrails
+
+- [x] 6.1 Update README development instructions to include the new mise security task.
+- [x] 6.2 Update `CONTRIBUTING.md` to explain security verification, supply-chain policy exceptions, and deferred release automation.
+- [x] 6.3 Update the pull request template if needed so contributors can report security verification results.
+- [x] 6.4 Ensure documentation states that release publishing workflows, crates.io token handling, and automated GitHub releases remain out of scope until a later usable-product milestone.
+
+## 7. Verification
+
+- [x] 7.1 Run `openspec validate adopt-production-readiness-workflow --strict`.
+- [x] 7.2 Run `mise run security` or the new granular security task set.
+- [x] 7.3 Run `mise run ci`.
+- [x] 7.4 Run `mise run hk-check`.
+- [x] 7.5 Confirm no release workflow or publishing credential requirement was introduced.
+- [x] 7.6 Confirm `cargo-vet` is not required for local or CI success in this change.

--- a/openspec/specs/development-workflow/spec.md
+++ b/openspec/specs/development-workflow/spec.md
@@ -58,3 +58,97 @@ The repository SHALL include lightweight CI validation that catches pull request
 #### Scenario: Non-PR CI does not require PR body metadata
 - **WHEN** CI runs for a push event without pull request metadata
 - **THEN** OpenSpec evidence validation does not fail solely because no PR body exists
+
+### Requirement: Mise defines repository security verification
+The repository SHALL expose supply-chain and vulnerability checks through mise-defined tasks that can be run locally and from GitHub Actions.
+
+#### Scenario: Local security verification uses mise
+- **WHEN** a contributor reads the development workflow documentation
+- **THEN** it tells them to run repository security verification through `mise run security` or documented granular mise tasks
+
+#### Scenario: Security CI invokes mise verification
+- **WHEN** GitHub Actions runs repository security checks
+- **THEN** the workflow sets up mise tooling and invokes mise-defined security tasks instead of installing or running cargo security tools directly in workflow YAML
+
+#### Scenario: Security workflow covers routine triggers
+- **WHEN** maintainers inspect the security workflow triggers
+- **THEN** the workflow runs for pull requests, pushes to `main`, and scheduled checks
+
+#### Scenario: Security task preserves standard CI
+- **WHEN** maintainers add security verification tasks
+- **THEN** the existing `mise run ci` quality contract continues to run formatting, checking, clippy, tests, and documentation checks without being replaced by security-only checks
+
+### Requirement: Supply-chain policy is explicit and reviewable
+The repository SHALL include an initial supply-chain policy for Rust dependencies that covers vulnerability advisories, license allowances, duplicate dependency handling, registries, and git sources.
+
+#### Scenario: Cargo deny policy is present
+- **WHEN** a contributor runs the documented supply-chain policy check
+- **THEN** the check evaluates a repository `deny.toml` policy for advisories, licenses, duplicate crates, registries, and git sources
+
+#### Scenario: Unknown dependency sources are rejected
+- **WHEN** dependency resolution includes an unapproved registry or git source
+- **THEN** the supply-chain policy check fails with a clear source policy violation
+
+#### Scenario: Policy exceptions stay visible
+- **WHEN** a dependency requires a license, advisory, duplicate, registry, or git-source exception
+- **THEN** the exception is recorded in the repository policy instead of being hidden in ad hoc CI commands
+
+### Requirement: Cargo vet remains deferred until maintainable
+The repository SHALL NOT require `cargo-vet` as a blocking local or CI gate until a later change defines audit ownership, exemption policy, and maintenance expectations.
+
+#### Scenario: Cargo vet is not required by initial security verification
+- **WHEN** a contributor runs the initial documented security verification for this change
+- **THEN** it does not fail solely because `cargo-vet` audits or exemptions have not been initialized
+
+#### Scenario: Cargo vet is non-blocking in CI
+- **WHEN** GitHub Actions runs the initial security workflow for this change
+- **THEN** `cargo-vet` is absent from the required path or is explicitly configured as non-blocking
+
+#### Scenario: Future cargo vet adoption requires policy
+- **WHEN** maintainers decide to make `cargo-vet` blocking
+- **THEN** they first define the audit ownership and exemption policy in OpenSpec or contributor documentation
+
+### Requirement: Cargo workspace metadata is centralized for future distribution
+The repository SHALL centralize shared Cargo package metadata in the workspace manifest and use workspace inheritance where it does not change crate behavior.
+
+#### Scenario: Shared package metadata is inherited
+- **WHEN** maintainers inspect workspace and crate manifests
+- **THEN** shared metadata such as edition, rust-version, license, repository, homepage, and authors is defined once in `[workspace.package]` where appropriate and inherited by workspace crates
+
+#### Scenario: Crate-specific metadata remains local
+- **WHEN** a crate needs package-specific metadata such as name, description, readme, documentation, keywords, categories, or exclusions
+- **THEN** that metadata remains in the crate manifest or explicitly inherits only fields that preserve the crate's package identity
+
+#### Scenario: Metadata changes do not alter runtime behavior
+- **WHEN** workspace package metadata is centralized
+- **THEN** `oxmux` and `oxidemux` runtime behavior, public API semantics, and crate boundary responsibilities remain unchanged
+
+#### Scenario: Metadata changes preserve package identity
+- **WHEN** workspace package metadata and crate metadata are updated
+- **THEN** manifest validation confirms package names, crate targets, readme/documentation links, included files, and package-specific descriptions remain intentional without requiring release publishing
+
+### Requirement: Rust tool configuration remains subordinate to mise tasks
+The repository SHALL add explicit Rust tool configuration files only when they complement mise-defined checks and reduce environment drift.
+
+#### Scenario: Clippy configuration complements mise
+- **WHEN** maintainers add or update `clippy.toml`
+- **THEN** the configuration captures stable project-wide lint behavior without replacing `mise run clippy` as the contributor and CI entrypoint
+
+#### Scenario: Rustfmt configuration complements mise
+- **WHEN** maintainers add or update `rustfmt.toml`
+- **THEN** the configuration captures stable project-wide formatting behavior without replacing `mise run fmt` as the contributor and CI entrypoint
+
+#### Scenario: Tool configuration is omitted when redundant
+- **WHEN** explicit Rust tool configuration would only duplicate existing defaults or mise task commands
+- **THEN** the implementation omits that configuration and documents why no file was added
+
+### Requirement: Release automation is deferred until usable product readiness
+The repository SHALL defer release publishing workflows, crates.io token handling, and automated GitHub release creation until OxideMux has a usable product milestone and a separate release proposal.
+
+#### Scenario: Production-readiness workflow excludes publishing
+- **WHEN** this change is implemented
+- **THEN** it does not add a release publishing workflow, crates.io publishing steps, or required publishing credentials
+
+#### Scenario: Release readiness is documented as deferred
+- **WHEN** contributors read workflow documentation after this change
+- **THEN** it explains that release automation is intentionally deferred until a later usable-product milestone


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #35

## ✅ Type of Change

- [ ] ✨ New Project/Feature
- [ ] 🐞 Bug Fix
- [ ] 📚 Documentation Update
- [x] 🔨 Refactor or Other

## 📝 Summary

Adopts the OpenSpec-backed production-readiness workflow by adding mise-managed security verification, an explicit cargo-deny policy, and a dedicated GitHub security workflow.

Centralizes shared Cargo package metadata for future distribution review while documenting that release automation, crates.io credentials, and blocking cargo-vet adoption remain deferred.

## 📐 OpenSpec Evidence

- OpenSpec change/spec: `openspec/changes/adopt-production-readiness-workflow/`, `openspec/changes/adopt-production-readiness-workflow/specs/development-workflow/spec.md`
- No OpenSpec required: N/A
- Vision/boundary impact: No runtime, subscription UX, auth/session, request rewrite, routing, provider selection, GPUI, or crate-boundary behavior changes. This is repository tooling and metadata only.

## 📖 Documentation Checklist

- [x] I updated `README.md`, `CONTRIBUTING.md`, or OpenSpec docs when needed.
- [x] I updated `CHANGELOG.md` for notable user-facing, compatibility, security, or workflow changes, or explained why it was not applicable.

## ✔️ Contributor Checklist

- [x] My code follows the project's coding standards.
- [x] I have added a `.env.example` file if environment variables are needed and ensured no secrets are committed.
- [x] My pull request is focused on a single project or change.
- [x] I preserved the `oxmux` shared-core and `oxidemux` platform-shell boundary, or documented the OpenSpec-approved reason for changing it.
- [x] I ran `mise run ci` locally, or explained why it was not applicable.
- [x] I ran `mise run security` locally for dependency policy and vulnerability changes, or explained why it was not applicable.
- [x] I ran relevant hk checks with `mise run hk-check`, or explained why they were not applicable.

## 💬 Additional Comments

Verification performed locally:

- `openspec validate adopt-production-readiness-workflow --strict`
- `mise run security`
- `mise run ci`
- `mise run hk-check`
- `cargo package --list --allow-dirty -p oxmux`
- `cargo package --list --allow-dirty -p oxidemux`
- `git diff --check`

Release Notes:

- Added mise-backed dependency security verification and initial supply-chain policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WeShipWork/codesmith/oxidemux/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->