### PR TITLE
Document provider access roadmap

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,20 +1,21 @@
 # OxideMux Architecture Intent
 
-OxideMux is split into a shared product engine and a platform shell so that the
-subscription proxy behaves the same on Linux, macOS, Windows, and headless test
-consumers.
+OxideMux is split into a shared product engine and a platform shell so that
+provider access behavior works the same for subscription accounts, API-token
+accounts, credit/quota-limited accounts, pay-as-you-go providers, Linux, macOS,
+Windows, and headless test consumers.
 
 ```text
 developer tool / local client
   -> local OxideMux endpoint
   -> oxmux protocol + request rewrite pipeline
   -> oxmux model alias + reasoning/thinking normalization
-  -> oxmux subscription-aware routing policy
+  -> oxmux provider access-aware routing policy
   -> provider/account execution seam
   -> compatible response stream or response body
 
 platform shell
-  -> displays auth, quota, routing, health, and lifecycle state
+  -> displays auth, quota, cost/spend, routing, health, and lifecycle state
   -> supplies platform credential adapters and user choices
   -> starts/stops/backgrounds the shared runtime
 ```
@@ -30,15 +31,16 @@ testable, and available outside the desktop app:
   payload semantics;
 - reasoning/thinking-mode normalization and token/budget semantics;
 - model aliases and explicit provider/account targets;
-- subscription-aware routing inputs, selection outcomes, degraded/exhausted
-  states, and structured routing errors;
+- provider access-aware routing inputs, selection outcomes,
+  degraded/exhausted/over-budget states, and structured routing errors;
 - provider execution traits, mock harnesses, and account/capability summaries;
-- usage/quota summaries, management snapshots, and configuration state.
+- usage/quota/cost summaries, management snapshots, and configuration state.
 
-The core may describe auth/session semantics and credential references, but it
-must not own OAuth UI, platform secret-store implementation, GPUI state, tray
-libraries, packaging, updaters, or provider SDK dependencies unless an accepted
-OpenSpec change explicitly revises the boundary.
+The core must define typed, dependency-free interfaces for auth/session
+semantics and credential references. Implementations that require platform UI,
+secret stores, browser/OAuth presentation, or provider SDKs must live in
+`oxidemux` or app-owned adapter crates unless an accepted OpenSpec change
+explicitly revises the boundary.
 
 ## `oxidemux` owns platform behavior
 
@@ -51,12 +53,14 @@ native app on Linux, macOS, and Windows:
 - platform credential storage adapters and browser/OAuth presentation flows;
 - user-visible subscription onboarding, restore, auth repair, and account
   selection flows;
-- presentation of core state: quota pressure, account health, provider status,
-  selected route, fallback reason, and next recovery action.
+- presentation of core state: quota pressure, cost/spend pressure, account
+  health, credential health, provider status, selected route, fallback reason,
+  and next recovery action.
 
 The shell must not duplicate routing, provider, quota, request rewrite,
-thinking/reasoning, protocol, or management decision logic. It supplies inputs
-to `oxmux` and renders outputs from `oxmux`.
+thinking/reasoning, protocol, or management decision logic. It supplies user and
+platform inputs to `oxmux`, invokes `oxmux` control surfaces, and renders outputs
+from `oxmux`.
 
 ## Boundary test
 
@@ -67,6 +71,87 @@ Before adding behavior, ask:
 2. Does this require a desktop OS, window, tray/menu, updater, notification, or
    platform credential store? Put the implementation in `oxidemux` or an
    app-owned adapter.
-3. Does this affect subscription UX, auth/session behavior, request rewriting,
-   model aliases, thinking/reasoning behavior, routing, or crate boundaries?
+3. Does this affect provider access UX, auth/session behavior, credential
+   behavior, cost/spend behavior, request rewriting, model aliases,
+   thinking/reasoning behavior, routing, or crate boundaries?
    Update OpenSpec before implementation.
+
+## Core state contract
+
+`oxmux` owns the provider access UX semantics that callers need even without
+the native app. Subscription accounts, API-token accounts, provider credits,
+quota-limited plans, and pay-as-you-go providers must all flow through the same
+typed core model. `oxmux` must expose enough snapshots, structured events, and
+outcomes for headless tools to inspect and control provider state directly,
+while `oxidemux` turns the same contracts into a visual, interactive,
+platform-native control surface. Core contracts must expose, at minimum:
+
+- proxy lifecycle and bound endpoint state;
+- provider and account health, capability, degraded, and unavailable states;
+- auth/session status, API-token credential-reference health, and access method
+  metadata without raw secrets;
+- usage, quota, credit, and cost/spend summaries with warning, exhausted, or
+  over-budget states;
+- routing decisions that include selected provider/account/model, skipped
+  candidates, fallback reasons, budget/cost rationale, and recovery actions;
+- compatibility outcomes for protocol translation, model alias resolution, and
+  reasoning/thinking normalization;
+- structured errors that distinguish invalid configuration, missing credentials,
+  exhausted quota, depleted credits, over-budget spend, unavailable providers,
+  and provider execution failures.
+
+## Roadmap sequencing
+
+The project should stay core-first until `oxmux` can accept, normalize, route,
+execute, and return a minimal local proxy request with observable provider
+access state. Current roadmap phases should be interpreted as:
+
+| Phase | Primary owner | Purpose | Blocks |
+| --- | --- | --- | --- |
+| Phase 2 - Core proxy contracts | `oxmux` | protocol, model registry, thinking/reasoning, streaming, WebSocket and management contracts | provider execution and app status UX |
+| Phase 3 - Provider state, quota, and spend | `oxmux` | credential boundary, account monitoring, quota/cost events, real provider adapter, quota- and spend-aware failover | settings, dashboards, recovery UX |
+| Phase 4 - Desktop shell | `oxidemux` | GPUI status, settings, onboarding, provider configuration views | depends on stable core snapshots |
+| Phase 5 - Desktop lifecycle and distribution | `oxidemux` | tray/background lifecycle, launch at login, analytics surfaces, packaging, updates | depends on usable runtime and shell state |
+
+Desktop work may spike GPUI feasibility early, but production UX should not
+encode routing, quota, auth, or rewrite semantics that are not already available
+through `oxmux` contracts.
+
+## Testing expectations
+
+Changes to provider access UX, auth/session behavior, credential behavior,
+cost/spend behavior, request rewriting, model aliases, reasoning/thinking
+behavior, routing, provider selection, or crate boundaries require OpenSpec
+coverage before implementation. Core behavior must
+include deterministic tests for normal, quota-pressure, cost/spend-pressure, degraded/unavailable, and
+provider-failure cases. App-shell behavior must include tests or documented
+manual checks proving it renders core state and does not duplicate core decision
+logic.
+
+## Secrets, privacy, and adapters
+
+`oxmux` may carry credential references, access-method metadata, auth state,
+usage estimates, cost/spend summaries, and redacted diagnostics, but it must
+never persist raw platform secrets or require a platform secret-store crate. `oxidemux` and app-owned adapters own keychain, Secret Service, Windows
+Credential Manager, browser/OAuth presentation, notifications, updater,
+packaging, and OS lifecycle integrations. Telemetry or analytics must be based
+on scrubbed typed events and must not include raw API keys, cookies, bearer
+tokens, or provider session material.
+
+## Enforcement and review
+
+Every PR that touches `crates/oxmux`, provider access UX, auth/session
+behavior, credential behavior, cost/spend behavior, request rewriting, model
+aliases, reasoning/thinking behavior, routing, provider selection, or crate
+boundaries must link the relevant OpenSpec change
+or explain why the change is documentation-only. Reviews should verify:
+
+- `oxmux` has no dependency on GPUI, gpui-component, tray libraries, updater
+  libraries, packaging tools, platform credential storage libraries, provider
+  SDKs, OAuth UI libraries, Tauri, Electron, or the `oxidemux` app crate;
+- `oxidemux` consumes `oxmux` snapshots, events, traits, and errors rather than
+  creating parallel routing, quota, cost/spend, provider, protocol, or rewrite
+  models;
+- reference-product features are adopted as product behavior with attribution in
+  OpenSpec, not copied code, stack choices, or file structure;
+- `mise run ci` and relevant targeted tests cover changed contracts.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -122,8 +122,8 @@ through `oxmux` contracts.
 Changes to provider access UX, auth/session behavior, credential behavior,
 cost/spend behavior, request rewriting, model aliases, reasoning/thinking
 behavior, routing, provider selection, or crate boundaries require OpenSpec
-coverage before implementation. Core behavior must
-include deterministic tests for normal, quota-pressure, cost/spend-pressure, degraded/unavailable, and
+coverage before implementation. Core behavior must include deterministic tests
+for normal, quota-pressure, cost/spend-pressure, degraded/unavailable, and
 provider-failure cases. App-shell behavior must include tests or documented
 manual checks proving it renders core state and does not duplicate core decision
 logic.
@@ -132,7 +132,9 @@ logic.
 
 `oxmux` may carry credential references, access-method metadata, auth state,
 usage estimates, cost/spend summaries, and redacted diagnostics, but it must
-never persist raw platform secrets or require a platform secret-store crate. `oxidemux` and app-owned adapters own keychain, Secret Service, Windows
+never persist raw platform secrets or require a platform secret-store crate.
+
+`oxidemux` and app-owned adapters own keychain, Secret Service, Windows
 Credential Manager, browser/OAuth presentation, notifications, updater,
 packaging, and OS lifecycle integrations. Telemetry or analytics must be based
 on scrubbed typed events and must not include raw API keys, cookies, bearer
@@ -143,8 +145,8 @@ tokens, or provider session material.
 Every PR that touches `crates/oxmux`, provider access UX, auth/session
 behavior, credential behavior, cost/spend behavior, request rewriting, model
 aliases, reasoning/thinking behavior, routing, provider selection, or crate
-boundaries must link the relevant OpenSpec change
-or explain why the change is documentation-only. Reviews should verify:
+boundaries must link the relevant OpenSpec change or explain why the change is
+documentation-only. Reviews should verify:
 
 - `oxmux` has no dependency on GPUI, gpui-component, tray libraries, updater
   libraries, packaging tools, platform credential storage libraries, provider

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -1,11 +1,12 @@
 # OxideMux Vision
 
 OxideMux exists because VibeProxy and zero-limit prove that developers want
-subscription-aware local AI proxying, but they do not provide the cross-platform
-Linux, macOS, and Windows experience this project needs. The product center is
-subscription UX: users should understand account status, auth health,
-quota/rate-limit pressure, provider availability, routing behavior, and recovery
-paths without reading logs or hand-editing proxy state.
+subscription-aware local AI proxying, but this project also needs to support
+regular provider API tokens, credits, and pay-as-you-go billing with first-class
+Linux, macOS, and Windows UX. The product center is provider access UX: users
+should understand account status, auth health, quota/rate-limit pressure,
+cost/spend pressure, provider availability, routing behavior, and recovery paths
+without reading logs or hand-editing proxy state.
 
 OxideMux should feel like a native always-on utility. The tray/menu experience
 must have platform-appropriate implementations on Linux, macOS, and Windows, but
@@ -27,30 +28,52 @@ those shells adapt shared behavior rather than redefining it.
 OxideMux is an independent Rust implementation of those product lessons with a
 clearer shared-core boundary and first-class cross-platform support.
 
+## Reference adoption criteria
+
+Adopt reference-product behavior only when it strengthens the OxideMux product
+model without importing the reference implementation shape:
+
+1. The behavior must be expressible as typed Rust semantics in `oxmux` or as a
+   native platform-shell concern in `oxidemux`.
+2. The OpenSpec change must name which reference validates the behavior and why
+   it belongs in the current phase.
+3. Core behavior must have deterministic tests that do not require real provider
+   credentials, desktop UI, or network calls.
+4. Desktop behavior must render or adapt core state instead of reimplementing
+   routing, quota, auth, protocol, or rewrite decisions.
+5. Electron, Tauri, React, SwiftUI, AppKit, Go services, and upstream code
+   structure are non-goals. OxideMux copies product lessons, not code or stack.
+
+
 ## Core product intent
 
-- Subscription UX is the star of the application, not an add-on to a generic
-  proxy.
+- Provider access UX is the star of the application, not an add-on to a generic
+  proxy. Subscription accounts, API-token accounts, credits, quotas, and
+  pay-as-you-go spend should all be represented explicitly.
 - Local clients should keep using familiar OpenAI-compatible or provider-shaped
   APIs while OxideMux normalizes requests, maps aliases, applies reasoning or
   thinking options, routes across accounts/providers, and returns compatible
   responses.
-- Provider availability, subscription state, quota pressure, degraded states,
-  and fallback decisions must be represented as typed state that can be tested
+- Provider availability, access method, subscription state, API-token state,
+  credit balance, quota pressure, cost/spend pressure, degraded states, and
+  fallback decisions must be represented as typed state that can be tested
   without a desktop shell.
 - Auth redirects, cookies, credential references, and provider session health
   must be treated as user-facing product flows because broken auth is broken
   subscription UX.
-- Desktop UI should explain what the core is doing: which account/provider was
-  chosen, why fallback happened, what quota/auth state blocks a route, and what
-  the user can do next.
+- `oxmux` should explain what the core is doing through typed state and
+  structured outcomes: which account/provider was chosen, why fallback happened,
+  what quota, spend, credential, or auth state blocks a route, and what the
+  caller or user can do next.
+  `oxidemux` should make that experience visual, interactive, and
+  platform-native.
 
 ## Crate responsibility rule
 
 `oxmux` is the shared headless product engine. It owns provider protocols, auth
 semantics, request rewriting, reasoning/thinking compatibility primitives,
 model aliases, routing policy, management/status contracts, configuration,
-usage/quota state, and testable decision logic.
+usage/quota/cost state, and testable decision logic.
 
 `oxidemux` is the platform shell. It owns GPUI views, tray/menu integration,
 windows, notifications, packaging, updater behavior, platform credential storage
@@ -74,3 +97,36 @@ Use this rule when placing new behavior:
 - Do not make `oxmux` depend on GPUI, tray libraries, provider SDKs, platform
   secret stores, or OAuth UI. The core can define typed semantics and seams;
   shell/platform adapters provide concrete OS integrations.
+
+## Glossary
+
+The older phrase **Subscription UX** is a subset of provider access UX: it covers
+subscription-backed access, while OxideMux also supports regular API-token,
+credit, quota, and spend-tracked providers.
+
+
+- **Provider access UX**: the end-to-end experience of using subscription
+  accounts, API-token accounts, provider credits, quota-limited plans, and
+  pay-as-you-go providers through OxideMux. It includes the core semantics that
+  determine and explain account health, auth state, credential state, quota
+  pressure, cost/spend pressure, provider availability, routing choices,
+  fallback reasons, and recovery actions. `oxmux` must expose this information
+  without `oxidemux`; `oxidemux` makes it visual, interactive, and
+  platform-native.
+- **Provider/account state**: typed core data describing provider availability,
+  account identity, access method, auth/session health, credential health, quota
+  status, credit or spend status, capabilities, degraded conditions, and
+  recovery hints.
+- **Model alias**: a user- or provider-facing model name that `oxmux` resolves to
+  an explicit provider, account, and provider-native model target before
+  execution.
+- **Compatibility shim**: deterministic request or response normalization that
+  lets OpenAI-compatible or provider-shaped clients keep working while OxideMux
+  routes through provider accounts with subscriptions, API tokens, credits,
+  quotas, or pay-as-you-go billing.
+- **Reasoning/thinking normalization**: deterministic handling of reasoning
+  budgets, thinking-mode options, and provider-specific payload conventions so
+  routing and execution receive explicit typed intent.
+- **Provider/account execution seam**: the trait-based boundary where `oxmux`
+  hands a normalized request to a provider/account adapter and receives a
+  compatible response, stream, or structured failure.

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -44,7 +44,6 @@ model without importing the reference implementation shape:
 5. Electron, Tauri, React, SwiftUI, AppKit, Go services, and upstream code
    structure are non-goals. OxideMux copies product lessons, not code or stack.
 
-
 ## Core product intent
 
 - Provider access UX is the star of the application, not an add-on to a generic
@@ -89,7 +88,7 @@ Use this rule when placing new behavior:
 
 - Do not reduce VibeProxy or zero-limit to vague inspiration. Treat them as
   validated product references with an unresolved Linux/cross-platform gap.
-- Do not move subscription-aware routing, request rewrite, model alias,
+- Do not move provider access-aware routing, request rewrite, model alias,
   thinking/reasoning, or protocol compatibility behavior into the desktop shell
   just because the UI exposes it.
 - Do not start with tray, packaging, themes, or updater work if the core cannot
@@ -103,7 +102,6 @@ Use this rule when placing new behavior:
 The older phrase **Subscription UX** is a subset of provider access UX: it covers
 subscription-backed access, while OxideMux also supports regular API-token,
 credit, quota, and spend-tracked providers.
-
 
 - **Provider access UX**: the end-to-end experience of using subscription
   accounts, API-token accounts, provider credits, quota-limited plans, and


### PR DESCRIPTION
## 🔗 Linked Issue

Refs #1

## ✅ Type of Change

- [ ] ✨ New Project/Feature
- [ ] 🐞 Bug Fix
- [x] 📚 Documentation Update
- [ ] 🔨 Refactor or Other

## 📝 Summary

- Clarifies provider access UX as the broader product model covering subscriptions, API tokens, credits, quotas, and cost/spend pressure.
- Adds reference adoption criteria, glossary, core state contracts, roadmap sequencing, testing expectations, secrets/privacy guidance, and boundary enforcement.
- Preserves `oxmux` as the headless semantic/control layer and `oxidemux` as the native visual/controller shell.

## 📐 OpenSpec Evidence

- OpenSpec change/spec: Existing specs in `openspec/specs/oxmux-core/spec.md`, `openspec/specs/oxidemux-app-shell/spec.md`, and `openspec/specs/oxmux-management-lifecycle/spec.md` remain the canonical behavioral requirements.
- No OpenSpec required: Documentation-only clarification of product vocabulary, roadmap sequencing, and existing boundary expectations.
- Vision/boundary impact: Strengthens the boundary by making `oxmux` own provider access semantics headlessly while `oxidemux` renders and controls those semantics without duplicating core decision logic.

## 📖 Documentation Checklist

- [x] I updated `README.md`, `CONTRIBUTING.md`, or OpenSpec docs when needed.
- [x] I updated `CHANGELOG.md` for notable user-facing, compatibility, security, or workflow changes, or explained why it was not applicable.
  - Not applicable: documentation intent/architecture clarification only; no released user-facing behavior changed.

## ✔️ Contributor Checklist

- [x] My code follows the project's coding standards.
- [x] I have added a `.env.example` file if environment variables are needed and ensured no secrets are committed.
- [x] My pull request is focused on a single project or change.
- [x] I preserved the `oxmux` shared-core and `oxidemux` platform-shell boundary, or documented the OpenSpec-approved reason for changing it.
- [x] I ran `mise run ci` locally, or explained why it was not applicable.
  - Not applicable: docs-only change; LSP diagnostics were run for both modified markdown files.
- [x] I ran `mise run security` locally for dependency policy and vulnerability changes, or explained why they were not applicable.
  - Not applicable: no dependency, policy, or vulnerability changes.
- [x] I ran relevant hk checks with `mise run hk-check`, or explained why they were not applicable.
  - Not applicable: docs-only change; branch contains only markdown documentation updates.

## 💬 Additional Comments

PRD #1 was also updated in GitHub to use the same provider access terminology and to act as the source-of-truth roadmap index.

Release Notes:

- N/A

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WeShipWork/codesmith/oxidemux/pr/43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->