### PR TITLE
oxmux: Add model registry listing

### DIFF
--- a/crates/oxmux/src/model_registry.rs
+++ b/crates/oxmux/src/model_registry.rs
@@ -1,0 +1,693 @@
+//! Static model registry and listing contracts for the headless core.
+//!
+//! The registry describes configured model entries, aliases, provider-native
+//! targets, provider/account applicability, and listing state. It does not query
+//! providers, validate credentials, inspect quotas, perform routing selection, or
+//! execute provider requests.
+
+use crate::configuration::ValidatedFileConfiguration;
+use crate::provider::{AuthMethodCategory, DegradedReason, ProtocolFamily, ProviderSummary};
+use crate::routing::{
+    RoutingAvailabilitySnapshot, RoutingAvailabilityState, RoutingPolicy, RoutingTarget,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Deterministic model registry built from static core configuration inputs.
+pub struct ModelRegistry {
+    /// Ordered configured model entries.
+    pub entries: Vec<ModelRegistryEntry>,
+}
+
+impl ModelRegistry {
+    /// Builds a registry from routing policy and provider summaries without availability metadata.
+    pub fn from_policy(policy: &RoutingPolicy, providers: &[ProviderSummary]) -> Self {
+        Self::from_policy_with_availability(policy, providers, None)
+    }
+
+    /// Builds a registry from routing policy, provider summaries, and optional availability metadata.
+    pub fn from_policy_with_availability(
+        policy: &RoutingPolicy,
+        providers: &[ProviderSummary],
+        availability: Option<&RoutingAvailabilitySnapshot>,
+    ) -> Self {
+        let entries = policy
+            .routes
+            .iter()
+            .flat_map(|route| {
+                let aliases: Vec<&crate::routing::ModelAlias> = policy
+                    .model_aliases
+                    .iter()
+                    .filter(|alias| alias.resolved_model == route.resolved_model)
+                    .collect();
+                let candidates = route
+                    .candidates
+                    .iter()
+                    .enumerate()
+                    .map(|(candidate_order, candidate)| {
+                        ModelRegistryCandidate::from_target(
+                            &route.resolved_model,
+                            &candidate.target,
+                            candidate_order,
+                            None,
+                            Some(policy.fallback.fallback_enabled),
+                            providers,
+                            availability,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+
+                let canonical = ModelRegistryEntry::new(
+                    ListedModelIdentity::new(&route.resolved_model, &route.resolved_model),
+                    None,
+                    ModelForkMetadata::from_candidate_count(candidates.len()),
+                    candidates.clone(),
+                );
+
+                let alias_entries = aliases.into_iter().map(move |alias| {
+                    ModelRegistryEntry::new(
+                        ListedModelIdentity::new(&alias.requested_model, &route.resolved_model),
+                        Some(ModelAliasMetadata::new(
+                            &alias.requested_model,
+                            &alias.resolved_model,
+                        )),
+                        ModelForkMetadata::from_candidate_count(candidates.len()),
+                        candidates.clone(),
+                    )
+                });
+
+                std::iter::once(canonical).chain(alias_entries)
+            })
+            .collect();
+
+        Self { entries }
+    }
+
+    /// Builds a registry from validated file-backed configuration.
+    pub fn from_file_configuration(configuration: &ValidatedFileConfiguration) -> Self {
+        let providers = configuration.provider_summaries();
+        Self::from_file_configuration_with_availability(configuration, &providers, None)
+    }
+
+    /// Builds a registry from validated file-backed configuration, provider summaries, and optional availability metadata.
+    pub fn from_file_configuration_with_availability(
+        configuration: &ValidatedFileConfiguration,
+        providers: &[ProviderSummary],
+        availability: Option<&RoutingAvailabilitySnapshot>,
+    ) -> Self {
+        let entries = configuration
+            .routing_default_groups
+            .iter()
+            .map(|group| {
+                let candidates = group
+                    .candidates
+                    .iter()
+                    .enumerate()
+                    .map(|(candidate_order, candidate)| {
+                        ModelRegistryCandidate::from_target(
+                            &candidate.model,
+                            &candidate.target,
+                            candidate_order,
+                            Some(&candidate.name),
+                            Some(candidate.fallback_enabled),
+                            providers,
+                            availability,
+                        )
+                    })
+                    .collect::<Vec<_>>();
+
+                ModelRegistryEntry::new(
+                    ListedModelIdentity::new(&group.model, &group.model),
+                    None,
+                    ModelForkMetadata::from_candidate_count(candidates.len()),
+                    candidates,
+                )
+            })
+            .collect();
+
+        Self { entries }
+    }
+
+    /// Returns all configured entries in deterministic registry order.
+    pub fn all_entries(&self) -> &[ModelRegistryEntry] {
+        &self.entries
+    }
+
+    /// Returns entries with at least one visible and routable candidate.
+    pub fn visible_entries(&self) -> Vec<&ModelRegistryEntry> {
+        self.entries
+            .iter()
+            .filter(|entry| {
+                entry
+                    .candidates
+                    .iter()
+                    .any(ModelRegistryCandidate::is_visible)
+            })
+            .collect()
+    }
+
+    /// Returns entries with at least one disabled or routing-ineligible candidate.
+    pub fn disabled_entries(&self) -> Vec<&ModelRegistryEntry> {
+        self.entries
+            .iter()
+            .filter(|entry| {
+                entry
+                    .candidates
+                    .iter()
+                    .any(ModelRegistryCandidate::is_disabled)
+            })
+            .collect()
+    }
+
+    /// Returns entries with at least one degraded candidate.
+    pub fn degraded_entries(&self) -> Vec<&ModelRegistryEntry> {
+        self.entries
+            .iter()
+            .filter(|entry| {
+                entry
+                    .candidates
+                    .iter()
+                    .any(ModelRegistryCandidate::is_degraded)
+            })
+            .collect()
+    }
+
+    /// Returns entries matching one deterministic listing filter.
+    pub fn entries_matching(&self, filter: ModelListingFilter) -> Vec<&ModelRegistryEntry> {
+        match filter {
+            ModelListingFilter::AllConfigured => self.entries.iter().collect(),
+            ModelListingFilter::Visible => self.visible_entries(),
+            ModelListingFilter::Disabled => self.disabled_entries(),
+            ModelListingFilter::Degraded => self.degraded_entries(),
+        }
+    }
+
+    /// Projects visible entries into the minimal OpenAI-compatible model list shape.
+    pub fn open_ai_model_list(&self) -> OpenAiModelListProjection {
+        OpenAiModelListProjection::from_entries(self.visible_entries())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// One listed model and its configured provider/account candidates.
+pub struct ModelRegistryEntry {
+    /// Listed and resolved model identity metadata.
+    pub identity: ListedModelIdentity,
+    /// Alias metadata when this entry was created from a requested alias.
+    pub alias: Option<ModelAliasMetadata>,
+    /// Fork metadata describing whether this listed model fans out to multiple targets.
+    pub fork: ModelForkMetadata,
+    /// Ordered provider/account candidates for this listed model.
+    pub candidates: Vec<ModelRegistryCandidate>,
+}
+
+impl ModelRegistryEntry {
+    /// Creates one registry entry from typed identity, alias, fork, and candidate metadata.
+    pub fn new(
+        identity: ListedModelIdentity,
+        alias: Option<ModelAliasMetadata>,
+        fork: ModelForkMetadata,
+        candidates: Vec<ModelRegistryCandidate>,
+    ) -> Self {
+        Self {
+            identity,
+            alias,
+            fork,
+            candidates,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Listed model identity with user-facing and resolved model identifiers kept separate.
+pub struct ListedModelIdentity {
+    /// Model identifier exposed to callers and listing consumers.
+    pub listed_model_id: String,
+    /// Model identifier after applying core alias metadata.
+    pub resolved_model_id: String,
+}
+
+impl ListedModelIdentity {
+    /// Creates listed model identity metadata.
+    pub fn new(listed_model_id: impl Into<String>, resolved_model_id: impl Into<String>) -> Self {
+        Self {
+            listed_model_id: listed_model_id.into(),
+            resolved_model_id: resolved_model_id.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Provider-native model target for one routing candidate.
+pub struct ProviderNativeModelTarget {
+    /// Provider-native model identifier sent to the selected provider in future execution paths.
+    pub provider_native_model_id: String,
+    /// Provider/account target associated with this native model.
+    pub target: RoutingTarget,
+}
+
+impl ProviderNativeModelTarget {
+    /// Creates provider-native model target metadata.
+    pub fn new(provider_native_model_id: impl Into<String>, target: RoutingTarget) -> Self {
+        Self {
+            provider_native_model_id: provider_native_model_id.into(),
+            target,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Alias metadata preserving requested and resolved model identifiers.
+pub struct ModelAliasMetadata {
+    /// User-facing requested model identifier.
+    pub requested_model_id: String,
+    /// Resolved model identifier used by routing policy metadata.
+    pub resolved_model_id: String,
+}
+
+impl ModelAliasMetadata {
+    /// Creates alias metadata for a requested-to-resolved model mapping.
+    pub fn new(
+        requested_model_id: impl Into<String>,
+        resolved_model_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            requested_model_id: requested_model_id.into(),
+            resolved_model_id: resolved_model_id.into(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Metadata describing whether a listed model has multiple candidate targets.
+pub struct ModelForkMetadata {
+    /// Whether this listed model has more than one configured candidate target.
+    pub forked: bool,
+    /// Number of configured candidate targets under this listed model.
+    pub candidate_count: usize,
+}
+
+impl ModelForkMetadata {
+    /// Creates fork metadata from a candidate count.
+    pub const fn from_candidate_count(candidate_count: usize) -> Self {
+        Self {
+            forked: candidate_count > 1,
+            candidate_count,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// One ordered provider/account candidate for a registry entry.
+pub struct ModelRegistryCandidate {
+    /// Provider-native model target metadata.
+    pub native_target: ProviderNativeModelTarget,
+    /// Candidate ordering and file-routing default metadata.
+    pub candidate: RoutingCandidateMetadata,
+    /// Provider/account applicability metadata.
+    pub applicability: ProviderAccountApplicability,
+    /// Capability metadata derived from provider declarations or summaries.
+    pub capabilities: ModelCapabilityMetadata,
+    /// Listing state for disabled, degraded, unknown, or visible candidates.
+    pub listing_state: ModelListingState,
+}
+
+impl ModelRegistryCandidate {
+    /// Creates one model registry candidate from explicit typed metadata.
+    pub fn new(
+        native_target: ProviderNativeModelTarget,
+        candidate: RoutingCandidateMetadata,
+        applicability: ProviderAccountApplicability,
+        capabilities: ModelCapabilityMetadata,
+        listing_state: ModelListingState,
+    ) -> Self {
+        Self {
+            native_target,
+            candidate,
+            applicability,
+            capabilities,
+            listing_state,
+        }
+    }
+
+    /// Returns true when this candidate should be visible as routable configured catalog data.
+    pub fn is_visible(&self) -> bool {
+        matches!(
+            self.listing_state,
+            ModelListingState::Available | ModelListingState::Degraded { .. }
+        )
+    }
+
+    /// Returns true when this candidate is disabled, ineligible, unavailable, exhausted, or unknown.
+    pub fn is_disabled(&self) -> bool {
+        matches!(
+            self.listing_state,
+            ModelListingState::Disabled { .. }
+                | ModelListingState::RoutingIneligible { .. }
+                | ModelListingState::UnknownProvider { .. }
+                | ModelListingState::UnknownAccount { .. }
+        )
+    }
+
+    /// Returns true when this candidate has degraded metadata.
+    pub fn is_degraded(&self) -> bool {
+        matches!(self.listing_state, ModelListingState::Degraded { .. })
+    }
+
+    fn from_target(
+        provider_native_model_id: &str,
+        target: &RoutingTarget,
+        candidate_order: usize,
+        route_name: Option<&str>,
+        fallback_enabled: Option<bool>,
+        providers: &[ProviderSummary],
+        availability: Option<&RoutingAvailabilitySnapshot>,
+    ) -> Self {
+        let provider = providers
+            .iter()
+            .find(|provider| provider.provider_id == target.provider_id);
+        let account = provider.and_then(|provider| {
+            target.account_id.as_ref().map(|account_id| {
+                provider
+                    .accounts
+                    .iter()
+                    .any(|account| account.account_id == *account_id)
+            })
+        });
+        let capabilities = provider
+            .and_then(|provider| provider.capabilities.first())
+            .map(ModelCapabilityMetadata::from_capability)
+            .unwrap_or_else(ModelCapabilityMetadata::unknown);
+        let applicability = ProviderAccountApplicability::new(
+            target.provider_id.clone(),
+            target.account_id.clone(),
+            provider.is_some(),
+            account.unwrap_or(true),
+        );
+        let listing_state =
+            listing_state_for(provider, account, &capabilities, target, availability);
+
+        Self::new(
+            ProviderNativeModelTarget::new(provider_native_model_id, target.clone()),
+            RoutingCandidateMetadata::new(
+                candidate_order,
+                route_name.map(str::to_string),
+                fallback_enabled,
+            ),
+            applicability,
+            capabilities,
+            listing_state,
+        )
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Candidate order, route label, and fallback metadata supplied by routing configuration.
+pub struct RoutingCandidateMetadata {
+    /// Zero-based deterministic candidate order within the listed model.
+    pub candidate_order: usize,
+    /// Optional routing default or group name associated with this candidate.
+    pub route_name: Option<String>,
+    /// Optional fallback flag from routing policy or file-backed routing defaults.
+    pub fallback_enabled: Option<bool>,
+}
+
+impl RoutingCandidateMetadata {
+    /// Creates routing candidate metadata.
+    pub fn new(
+        candidate_order: usize,
+        route_name: Option<String>,
+        fallback_enabled: Option<bool>,
+    ) -> Self {
+        Self {
+            candidate_order,
+            route_name,
+            fallback_enabled,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Provider/account applicability metadata for one model candidate.
+pub struct ProviderAccountApplicability {
+    /// Provider identifier from routing target metadata.
+    pub provider_id: String,
+    /// Optional account identifier from routing target metadata.
+    pub account_id: Option<String>,
+    /// Whether provider metadata was supplied for this target.
+    pub provider_known: bool,
+    /// Whether account metadata was supplied or no account was requested.
+    pub account_known: bool,
+}
+
+impl ProviderAccountApplicability {
+    /// Creates provider/account applicability metadata.
+    pub fn new(
+        provider_id: impl Into<String>,
+        account_id: Option<String>,
+        provider_known: bool,
+        account_known: bool,
+    ) -> Self {
+        Self {
+            provider_id: provider_id.into(),
+            account_id,
+            provider_known,
+            account_known,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Protocol, auth, streaming, and routing eligibility metadata for one candidate.
+pub struct ModelCapabilityMetadata {
+    /// Protocol family associated with the provider capability, when known.
+    pub protocol_family: Option<ProtocolFamily>,
+    /// Whether the provider advertises streaming support.
+    pub supports_streaming: bool,
+    /// Authentication method category advertised by the provider, when known.
+    pub auth_method: Option<AuthMethodCategory>,
+    /// Whether routing may select this provider according to static metadata.
+    pub routing_eligible: bool,
+}
+
+impl ModelCapabilityMetadata {
+    /// Creates capability metadata from explicit values.
+    pub const fn new(
+        protocol_family: Option<ProtocolFamily>,
+        supports_streaming: bool,
+        auth_method: Option<AuthMethodCategory>,
+        routing_eligible: bool,
+    ) -> Self {
+        Self {
+            protocol_family,
+            supports_streaming,
+            auth_method,
+            routing_eligible,
+        }
+    }
+
+    /// Creates unknown capability metadata for missing provider state.
+    pub const fn unknown() -> Self {
+        Self::new(None, false, None, false)
+    }
+
+    fn from_capability(capability: &crate::provider::ProviderCapability) -> Self {
+        Self::new(
+            Some(capability.protocol_family),
+            capability.supports_streaming,
+            Some(capability.auth_method),
+            capability.routing_eligible,
+        )
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Listing state for one model candidate.
+pub enum ModelListingState {
+    /// Candidate is statically configured and routable.
+    Available,
+    /// Candidate is statically configured but disabled or unavailable.
+    Disabled {
+        /// Human-readable reason for disabled state.
+        reason: String,
+    },
+    /// Candidate provider is known but marked ineligible for routing.
+    RoutingIneligible {
+        /// Human-readable reason for routing-ineligible state.
+        reason: String,
+    },
+    /// Candidate is statically configured but degraded.
+    Degraded {
+        /// Reasons explaining degraded state.
+        reasons: Vec<DegradedReason>,
+    },
+    /// Candidate references an unknown provider.
+    UnknownProvider {
+        /// Human-readable reason for unknown provider state.
+        reason: String,
+    },
+    /// Candidate references an unknown account for a known provider.
+    UnknownAccount {
+        /// Human-readable reason for unknown account state.
+        reason: String,
+    },
+}
+
+impl ModelListingState {
+    /// Returns a human-readable reason for non-available listing states.
+    pub fn reason(&self) -> Option<String> {
+        match self {
+            Self::Available => None,
+            Self::Disabled { reason }
+            | Self::RoutingIneligible { reason }
+            | Self::UnknownProvider { reason }
+            | Self::UnknownAccount { reason } => Some(reason.clone()),
+            Self::Degraded { reasons } => Some(
+                reasons
+                    .iter()
+                    .map(|reason| format!("{}: {}", reason.component, reason.message))
+                    .collect::<Vec<_>>()
+                    .join("; "),
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Filter modes supported by deterministic model registry listing APIs.
+pub enum ModelListingFilter {
+    /// Include all configured registry entries.
+    AllConfigured,
+    /// Include entries with at least one visible/routable candidate.
+    Visible,
+    /// Include entries with at least one disabled candidate.
+    Disabled,
+    /// Include entries with at least one degraded candidate.
+    Degraded,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Minimal OpenAI-compatible model list projection derived from registry entries.
+pub struct OpenAiModelListProjection {
+    /// OpenAI-compatible object kind for list responses.
+    pub object: String,
+    /// Projected model entries.
+    pub data: Vec<OpenAiModelProjection>,
+}
+
+impl OpenAiModelListProjection {
+    /// Creates an OpenAI-compatible projection from visible registry entries.
+    pub fn from_entries(entries: Vec<&ModelRegistryEntry>) -> Self {
+        Self {
+            object: "list".to_string(),
+            data: entries
+                .into_iter()
+                .map(OpenAiModelProjection::from_registry_entry)
+                .collect(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Minimal OpenAI-compatible model projection for one registry entry.
+pub struct OpenAiModelProjection {
+    /// OpenAI-compatible model identifier.
+    pub id: String,
+    /// OpenAI-compatible object kind for model entries.
+    pub object: String,
+    /// Deterministic static timestamp placeholder for configured catalog data.
+    pub created: u64,
+    /// Provider ownership label derived from first visible candidate metadata.
+    pub owned_by: String,
+}
+
+impl OpenAiModelProjection {
+    /// Creates an OpenAI-compatible projection from one registry entry.
+    pub fn from_registry_entry(entry: &ModelRegistryEntry) -> Self {
+        let owned_by = entry
+            .candidates
+            .iter()
+            .find(|candidate| candidate.is_visible())
+            .map(|candidate| candidate.applicability.provider_id.clone())
+            .unwrap_or_else(|| "oxmux".to_string());
+
+        Self {
+            id: entry.identity.listed_model_id.clone(),
+            object: "model".to_string(),
+            created: 0,
+            owned_by,
+        }
+    }
+}
+
+fn listing_state_for(
+    provider: Option<&ProviderSummary>,
+    account_known: Option<bool>,
+    capabilities: &ModelCapabilityMetadata,
+    target: &RoutingTarget,
+    availability: Option<&RoutingAvailabilitySnapshot>,
+) -> ModelListingState {
+    let Some(provider) = provider else {
+        return ModelListingState::UnknownProvider {
+            reason: format!("provider {} is not declared", target.provider_id),
+        };
+    };
+
+    if account_known == Some(false) {
+        let account_id = target.account_id.as_deref().unwrap_or("<none>");
+        return ModelListingState::UnknownAccount {
+            reason: format!(
+                "account {account_id} is not declared for provider {}",
+                target.provider_id
+            ),
+        };
+    }
+
+    if !capabilities.routing_eligible {
+        return ModelListingState::RoutingIneligible {
+            reason: format!("provider {} is not routing eligible", target.provider_id),
+        };
+    }
+
+    if let Some(state) = availability.and_then(|availability| availability.state_for(target)) {
+        return match state {
+            RoutingAvailabilityState::Available => degraded_or_available(provider, target),
+            RoutingAvailabilityState::Degraded { reason } => ModelListingState::Degraded {
+                reasons: vec![DegradedReason {
+                    component: target_label(target),
+                    message: reason.clone(),
+                }],
+            },
+            RoutingAvailabilityState::Unavailable { reason }
+            | RoutingAvailabilityState::Exhausted { reason } => ModelListingState::Disabled {
+                reason: reason.clone(),
+            },
+        };
+    }
+
+    degraded_or_available(provider, target)
+}
+
+fn degraded_or_available(provider: &ProviderSummary, target: &RoutingTarget) -> ModelListingState {
+    let mut reasons = provider.degraded_reasons.clone();
+    if let Some(account_id) = &target.account_id
+        && let Some(account) = provider
+            .accounts
+            .iter()
+            .find(|account| account.account_id == *account_id)
+    {
+        reasons.extend(account.degraded_reasons.clone());
+    }
+
+    if reasons.is_empty() {
+        ModelListingState::Available
+    } else {
+        ModelListingState::Degraded { reasons }
+    }
+}
+
+fn target_label(target: &RoutingTarget) -> String {
+    match &target.account_id {
+        Some(account_id) => format!("{}/{}", target.provider_id, account_id),
+        None => target.provider_id.clone(),
+    }
+}

--- a/crates/oxmux/src/model_registry.rs
+++ b/crates/oxmux/src/model_registry.rs
@@ -373,6 +373,12 @@ impl ModelRegistryCandidate {
                     .any(|account| account.account_id == *account_id)
             })
         });
+        if let Some(provider) = provider {
+            debug_assert!(
+                provider.capabilities.len() <= 1,
+                "model registry currently projects a single provider capability per provider"
+            );
+        }
         let capabilities = provider
             .and_then(|provider| provider.capabilities.first())
             .map(ModelCapabilityMetadata::from_capability)
@@ -381,7 +387,7 @@ impl ModelRegistryCandidate {
             target.provider_id.clone(),
             target.account_id.clone(),
             provider.is_some(),
-            account.unwrap_or(true),
+            account.unwrap_or_else(|| target.account_id.is_none()),
         );
         let listing_state =
             listing_state_for(provider, account, &capabilities, target, availability);

--- a/crates/oxmux/src/oxmux.rs
+++ b/crates/oxmux/src/oxmux.rs
@@ -21,6 +21,8 @@ pub mod local_proxy_runtime;
 pub mod management;
 /// Minimal local proxy request, response, and smoke-route engine contracts.
 pub mod minimal_proxy;
+/// Static model registry and listing contracts.
+pub mod model_registry;
 /// Protocol metadata, payload, and deferred translation contracts.
 pub mod protocol;
 /// Provider execution, account summary, auth state, and mock harness contracts.
@@ -65,6 +67,12 @@ pub use minimal_proxy::{
     MAX_MINIMAL_PROXY_BODY_BYTES, MINIMAL_CHAT_COMPLETIONS_PATH, MINIMAL_PROXY_JSON_CONTENT_TYPE,
     MinimalProxyEngine, MinimalProxyEngineConfig, MinimalProxyErrorCode, MinimalProxyRequest,
     MinimalProxyResponse,
+};
+pub use model_registry::{
+    ListedModelIdentity, ModelAliasMetadata, ModelCapabilityMetadata, ModelForkMetadata,
+    ModelListingFilter, ModelListingState, ModelRegistry, ModelRegistryCandidate,
+    ModelRegistryEntry, OpenAiModelListProjection, OpenAiModelProjection,
+    ProviderAccountApplicability, ProviderNativeModelTarget, RoutingCandidateMetadata,
 };
 pub use protocol::{
     CanonicalProtocolRequest, CanonicalProtocolResponse, ClaudeProtocolMetadata,

--- a/crates/oxmux/tests/dependency_boundary.rs
+++ b/crates/oxmux/tests/dependency_boundary.rs
@@ -39,3 +39,30 @@ fn core_manifest_excludes_app_and_ui_dependencies() -> std::io::Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn model_registry_source_excludes_app_shell_and_runtime_imports() -> std::io::Result<()> {
+    let source_path = concat!(env!("CARGO_MANIFEST_DIR"), "/src/model_registry.rs");
+    let source = fs::read_to_string(source_path)?;
+
+    for forbidden_import in [
+        "use oxidemux",
+        "use gpui",
+        "use reqwest",
+        "use hyper",
+        "use ureq",
+        "use tokio",
+        "use smol",
+        "use async_std",
+        "use futures",
+        "use keyring",
+        "use secret_service",
+    ] {
+        assert!(
+            !source.contains(forbidden_import),
+            "model_registry source must not import {forbidden_import}"
+        );
+    }
+
+    Ok(())
+}

--- a/crates/oxmux/tests/model_registry.rs
+++ b/crates/oxmux/tests/model_registry.rs
@@ -279,6 +279,16 @@ fn filters_distinguish_visible_disabled_and_degraded_entries_without_execution()
         registry.all_entries()[3].candidates[0].listing_state,
         ModelListingState::UnknownProvider { .. }
     ));
+    assert!(
+        !registry.all_entries()[3].candidates[0]
+            .applicability
+            .provider_known
+    );
+    assert!(
+        !registry.all_entries()[3].candidates[0]
+            .applicability
+            .account_known
+    );
 }
 
 #[test]

--- a/crates/oxmux/tests/model_registry.rs
+++ b/crates/oxmux/tests/model_registry.rs
@@ -1,0 +1,487 @@
+//! Integration tests for static oxmux model registry listing.
+
+use oxmux::{
+    AccountSummary, AuthMethodCategory, AuthState, ConfigurationBoundary, DegradedReason,
+    FallbackBehavior, ModelAlias, ModelListingFilter, ModelListingState, ModelRegistry, ModelRoute,
+    ProtocolFamily, ProviderCapability, ProviderSummary, QuotaState, RoutingAvailabilitySnapshot,
+    RoutingAvailabilityState, RoutingCandidate, RoutingPolicy, RoutingTarget,
+    RoutingTargetAvailability,
+};
+
+const VALID_TOML: &str = include_str!("fixtures/file_configuration/valid.toml");
+
+#[test]
+fn in_memory_registry_preserves_aliases_forks_and_candidates_without_selection() {
+    let openai_target = RoutingTarget::provider_account("openai", "primary");
+    let claude_target = RoutingTarget::provider_account("claude", "fallback");
+    let policy = RoutingPolicy::new(vec![ModelRoute::new(
+        "gpt-4o",
+        vec![
+            RoutingCandidate::new(openai_target.clone()),
+            RoutingCandidate::new(claude_target.clone()),
+        ],
+    )])
+    .with_model_alias(ModelAlias::new("fast-chat", "gpt-4o"))
+    .with_fallback(FallbackBehavior::new(true, false));
+    let original_policy = policy.clone();
+    let providers = vec![
+        provider_summary("openai", ProtocolFamily::OpenAi, true, true, "primary"),
+        provider_summary("claude", ProtocolFamily::Claude, true, false, "fallback"),
+    ];
+
+    let registry = ModelRegistry::from_policy(&policy, &providers);
+
+    assert_eq!(policy, original_policy);
+    assert_eq!(registry.all_entries().len(), 2);
+    assert_eq!(registry.all_entries()[0].identity.listed_model_id, "gpt-4o");
+    assert_eq!(
+        registry.all_entries()[0].identity.resolved_model_id,
+        "gpt-4o"
+    );
+    assert!(registry.all_entries()[0].alias.is_none());
+    assert!(registry.all_entries()[0].fork.forked);
+    assert_eq!(registry.all_entries()[0].fork.candidate_count, 2);
+    assert_eq!(
+        registry.all_entries()[0].candidates[0]
+            .native_target
+            .provider_native_model_id,
+        "gpt-4o"
+    );
+    assert_eq!(
+        registry.all_entries()[0].candidates[1].native_target.target,
+        claude_target
+    );
+    assert_eq!(
+        registry.all_entries()[0].candidates[0]
+            .candidate
+            .fallback_enabled,
+        Some(true)
+    );
+    assert_eq!(
+        registry.all_entries()[0].candidates[1]
+            .candidate
+            .fallback_enabled,
+        Some(true)
+    );
+    assert_eq!(
+        registry.all_entries()[1].identity.listed_model_id,
+        "fast-chat"
+    );
+    assert_eq!(
+        registry.all_entries()[1]
+            .alias
+            .as_ref()
+            .map(|alias| (&alias.requested_model_id, &alias.resolved_model_id)),
+        Some((&"fast-chat".to_string(), &"gpt-4o".to_string()))
+    );
+}
+
+#[test]
+fn policy_registry_preserves_disabled_fallback_metadata() {
+    let policy = RoutingPolicy::new(vec![ModelRoute::new(
+        "single-shot-model",
+        vec![RoutingCandidate::new(RoutingTarget::provider("openai"))],
+    )])
+    .with_fallback(FallbackBehavior::disabled());
+    let providers = vec![provider_summary_without_account(
+        "openai",
+        ProtocolFamily::OpenAi,
+        true,
+        true,
+    )];
+
+    let registry = ModelRegistry::from_policy(&policy, &providers);
+
+    assert_eq!(
+        registry.all_entries()[0].candidates[0]
+            .candidate
+            .fallback_enabled,
+        Some(false)
+    );
+}
+
+#[test]
+fn file_configuration_builds_deterministic_registry_entries()
+-> Result<(), Box<dyn std::error::Error>> {
+    let configuration = ConfigurationBoundary::load_contents(VALID_TOML)?;
+
+    let first = ModelRegistry::from_file_configuration(&configuration);
+    let second = ModelRegistry::from_file_configuration(&configuration);
+
+    assert_eq!(first, second);
+    assert_eq!(first.all_entries().len(), 2);
+    assert_eq!(
+        first.all_entries()[0].identity.listed_model_id,
+        "gpt-4o-mini"
+    );
+    assert_eq!(first.all_entries()[0].fork.candidate_count, 2);
+    assert_eq!(
+        first.all_entries()[0].candidates[0]
+            .applicability
+            .provider_id,
+        "mock-openai"
+    );
+    assert_eq!(
+        first.all_entries()[0].candidates[0]
+            .applicability
+            .account_id,
+        Some("default".to_string())
+    );
+    assert_eq!(
+        first.all_entries()[0].candidates[0].candidate.route_name,
+        Some("chat".to_string())
+    );
+    assert_eq!(
+        first.all_entries()[0].candidates[0]
+            .candidate
+            .fallback_enabled,
+        Some(true)
+    );
+    assert_eq!(
+        first.all_entries()[0].candidates[1]
+            .capabilities
+            .protocol_family,
+        Some(ProtocolFamily::Claude)
+    );
+    assert!(
+        first.all_entries()[1].candidates[0]
+            .capabilities
+            .supports_streaming
+    );
+
+    Ok(())
+}
+
+#[test]
+fn file_configuration_can_surface_disabled_and_degraded_listing_metadata()
+-> Result<(), Box<dyn std::error::Error>> {
+    let configuration = ConfigurationBoundary::load_contents(VALID_TOML)?;
+    let disabled_target = RoutingTarget::provider_account("mock-openai", "default");
+    let degraded_target = RoutingTarget::provider_account("mock-claude", "fallback");
+    let availability = RoutingAvailabilitySnapshot::new(vec![
+        RoutingTargetAvailability::new(
+            disabled_target,
+            RoutingAvailabilityState::Unavailable {
+                reason: "disabled by operator".to_string(),
+            },
+        ),
+        RoutingTargetAvailability::new(
+            degraded_target,
+            RoutingAvailabilityState::Degraded {
+                reason: "provider quota pressure".to_string(),
+            },
+        ),
+    ]);
+    let providers = configuration.provider_summaries();
+
+    let registry = ModelRegistry::from_file_configuration_with_availability(
+        &configuration,
+        &providers,
+        Some(&availability),
+    );
+
+    assert_eq!(
+        model_ids_refs(registry.entries_matching(ModelListingFilter::Disabled)),
+        vec!["gpt-4o-mini"]
+    );
+    assert_eq!(
+        model_ids_refs(registry.entries_matching(ModelListingFilter::Degraded)),
+        vec!["gpt-4o-mini"]
+    );
+    assert!(matches!(
+        registry.all_entries()[0].candidates[0].listing_state,
+        ModelListingState::Disabled { .. }
+    ));
+    assert!(matches!(
+        registry.all_entries()[0].candidates[1].listing_state,
+        ModelListingState::Degraded { .. }
+    ));
+
+    Ok(())
+}
+
+#[test]
+fn filters_distinguish_visible_disabled_and_degraded_entries_without_execution() {
+    let policy = RoutingPolicy::new(vec![
+        ModelRoute::new(
+            "healthy-model",
+            vec![RoutingCandidate::new(RoutingTarget::provider_account(
+                "healthy", "default",
+            ))],
+        ),
+        ModelRoute::new(
+            "disabled-model",
+            vec![RoutingCandidate::new(RoutingTarget::provider_account(
+                "disabled", "default",
+            ))],
+        ),
+        ModelRoute::new(
+            "degraded-model",
+            vec![RoutingCandidate::new(RoutingTarget::provider_account(
+                "degraded", "default",
+            ))],
+        ),
+        ModelRoute::new(
+            "unknown-model",
+            vec![RoutingCandidate::new(RoutingTarget::provider_account(
+                "missing", "default",
+            ))],
+        ),
+    ]);
+    let providers = vec![
+        provider_summary("healthy", ProtocolFamily::OpenAi, true, true, "default"),
+        provider_summary("disabled", ProtocolFamily::OpenAi, false, true, "default"),
+        provider_summary("degraded", ProtocolFamily::Claude, true, true, "default")
+            .with_degraded("provider", "quota pressure"),
+    ];
+
+    let registry = ModelRegistry::from_policy(&policy, &providers);
+
+    assert_eq!(
+        model_ids(registry.all_entries()),
+        vec![
+            "healthy-model",
+            "disabled-model",
+            "degraded-model",
+            "unknown-model",
+        ]
+    );
+    assert_eq!(
+        model_ids_refs(registry.visible_entries()),
+        vec!["healthy-model", "degraded-model"]
+    );
+    assert_eq!(
+        model_ids_refs(registry.disabled_entries()),
+        vec!["disabled-model", "unknown-model"]
+    );
+    assert_eq!(
+        model_ids_refs(registry.degraded_entries()),
+        vec!["degraded-model"]
+    );
+    assert_eq!(
+        model_ids_refs(registry.entries_matching(ModelListingFilter::AllConfigured)),
+        vec![
+            "healthy-model",
+            "disabled-model",
+            "degraded-model",
+            "unknown-model",
+        ]
+    );
+    assert_eq!(
+        model_ids_refs(registry.entries_matching(ModelListingFilter::Visible)),
+        vec!["healthy-model", "degraded-model"]
+    );
+    assert!(matches!(
+        registry.all_entries()[1].candidates[0].listing_state,
+        ModelListingState::RoutingIneligible { .. }
+    ));
+    assert!(matches!(
+        registry.all_entries()[3].candidates[0].listing_state,
+        ModelListingState::UnknownProvider { .. }
+    ));
+}
+
+#[test]
+fn availability_metadata_marks_disabled_and_degraded_without_selecting_route() {
+    let primary = RoutingTarget::provider_account("openai", "primary");
+    let fallback = RoutingTarget::provider_account("openai", "fallback");
+    let policy = RoutingPolicy::new(vec![ModelRoute::new(
+        "gpt-4o",
+        vec![
+            RoutingCandidate::new(primary.clone()),
+            RoutingCandidate::new(fallback.clone()),
+        ],
+    )]);
+    let providers = vec![ProviderSummary {
+        accounts: vec![
+            account_summary("primary"),
+            account_summary("fallback").with_degraded("account", "reduced quota"),
+        ],
+        ..provider_summary("openai", ProtocolFamily::OpenAi, true, true, "primary")
+    }];
+    let availability = RoutingAvailabilitySnapshot::new(vec![
+        RoutingTargetAvailability::new(
+            primary,
+            RoutingAvailabilityState::Unavailable {
+                reason: "manually disabled".to_string(),
+            },
+        ),
+        RoutingTargetAvailability::new(
+            fallback,
+            RoutingAvailabilityState::Degraded {
+                reason: "limited capacity".to_string(),
+            },
+        ),
+    ]);
+
+    let registry =
+        ModelRegistry::from_policy_with_availability(&policy, &providers, Some(&availability));
+
+    assert!(matches!(
+        registry.all_entries()[0].candidates[0].listing_state,
+        ModelListingState::Disabled { .. }
+    ));
+    assert!(matches!(
+        registry.all_entries()[0].candidates[1].listing_state,
+        ModelListingState::Degraded { .. }
+    ));
+    assert_eq!(registry.visible_entries().len(), 1);
+    assert_eq!(registry.disabled_entries().len(), 1);
+    assert_eq!(registry.degraded_entries().len(), 1);
+}
+
+#[test]
+fn unknown_account_metadata_is_preserved_for_known_provider() {
+    let policy = RoutingPolicy::new(vec![ModelRoute::new(
+        "gpt-4o",
+        vec![RoutingCandidate::new(RoutingTarget::provider_account(
+            "openai",
+            "missing-account",
+        ))],
+    )]);
+    let providers = vec![provider_summary(
+        "openai",
+        ProtocolFamily::OpenAi,
+        true,
+        true,
+        "primary",
+    )];
+
+    let registry = ModelRegistry::from_policy(&policy, &providers);
+
+    assert!(
+        registry.all_entries()[0].candidates[0]
+            .applicability
+            .provider_known
+    );
+    assert!(
+        !registry.all_entries()[0].candidates[0]
+            .applicability
+            .account_known
+    );
+    assert!(matches!(
+        registry.all_entries()[0].candidates[0].listing_state,
+        ModelListingState::UnknownAccount { .. }
+    ));
+    assert_eq!(
+        model_ids_refs(registry.entries_matching(ModelListingFilter::Disabled)),
+        vec!["gpt-4o"]
+    );
+}
+
+#[test]
+fn open_ai_projection_uses_visible_registry_entries_only() {
+    let policy = RoutingPolicy::new(vec![
+        ModelRoute::new(
+            "visible-model",
+            vec![RoutingCandidate::new(RoutingTarget::provider("openai"))],
+        ),
+        ModelRoute::new(
+            "hidden-model",
+            vec![RoutingCandidate::new(RoutingTarget::provider("disabled"))],
+        ),
+    ]);
+    let providers = vec![
+        provider_summary_without_account("openai", ProtocolFamily::OpenAi, true, true),
+        provider_summary_without_account("disabled", ProtocolFamily::OpenAi, false, true),
+    ];
+
+    let projection = ModelRegistry::from_policy(&policy, &providers).open_ai_model_list();
+
+    assert_eq!(projection.object, "list");
+    assert_eq!(projection.data.len(), 1);
+    assert_eq!(projection.data[0].id, "visible-model");
+    assert_eq!(projection.data[0].object, "model");
+    assert_eq!(projection.data[0].created, 0);
+    assert_eq!(projection.data[0].owned_by, "openai");
+}
+
+fn provider_summary(
+    provider_id: &str,
+    protocol_family: ProtocolFamily,
+    routing_eligible: bool,
+    supports_streaming: bool,
+    account_id: &str,
+) -> ProviderSummary {
+    ProviderSummary {
+        provider_id: provider_id.to_string(),
+        display_name: provider_id.to_string(),
+        capabilities: vec![ProviderCapability {
+            protocol_family,
+            supports_streaming,
+            auth_method: AuthMethodCategory::ApiKey,
+            routing_eligible,
+        }],
+        accounts: vec![account_summary(account_id)],
+        degraded_reasons: Vec::new(),
+    }
+}
+
+fn provider_summary_without_account(
+    provider_id: &str,
+    protocol_family: ProtocolFamily,
+    routing_eligible: bool,
+    supports_streaming: bool,
+) -> ProviderSummary {
+    ProviderSummary {
+        provider_id: provider_id.to_string(),
+        display_name: provider_id.to_string(),
+        capabilities: vec![ProviderCapability {
+            protocol_family,
+            supports_streaming,
+            auth_method: AuthMethodCategory::ApiKey,
+            routing_eligible,
+        }],
+        accounts: Vec::new(),
+        degraded_reasons: Vec::new(),
+    }
+}
+
+fn account_summary(account_id: &str) -> AccountSummary {
+    AccountSummary {
+        account_id: account_id.to_string(),
+        display_name: account_id.to_string(),
+        auth_state: AuthState::Authenticated,
+        quota_state: QuotaState::Unknown,
+        last_checked: None,
+        degraded_reasons: Vec::new(),
+    }
+}
+
+trait WithDegradedReason {
+    fn with_degraded(self, component: &str, message: &str) -> Self;
+}
+
+impl WithDegradedReason for ProviderSummary {
+    fn with_degraded(mut self, component: &str, message: &str) -> Self {
+        self.degraded_reasons.push(DegradedReason {
+            component: component.to_string(),
+            message: message.to_string(),
+        });
+        self
+    }
+}
+
+impl WithDegradedReason for AccountSummary {
+    fn with_degraded(mut self, component: &str, message: &str) -> Self {
+        self.degraded_reasons.push(DegradedReason {
+            component: component.to_string(),
+            message: message.to_string(),
+        });
+        self
+    }
+}
+
+fn model_ids(entries: &[oxmux::ModelRegistryEntry]) -> Vec<&str> {
+    entries
+        .iter()
+        .map(|entry| entry.identity.listed_model_id.as_str())
+        .collect()
+}
+
+fn model_ids_refs(entries: Vec<&oxmux::ModelRegistryEntry>) -> Vec<&str> {
+    entries
+        .into_iter()
+        .map(|entry| entry.identity.listed_model_id.as_str())
+        .collect()
+}

--- a/openspec/changes/add-oxmux-model-registry-listing/.openspec.yaml
+++ b/openspec/changes/add-oxmux-model-registry-listing/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-01

--- a/openspec/changes/add-oxmux-model-registry-listing/design.md
+++ b/openspec/changes/add-oxmux-model-registry-listing/design.md
@@ -1,0 +1,71 @@
+## Context
+
+`oxmux` already owns typed protocol metadata, provider/account summaries, routing policy aliases, file-backed provider declarations, streaming capability metadata, management snapshots, and a minimal proxy route. Issue #26 asks for a model registry and listing contract so clients and the future `oxidemux` shell can discover configured models, aliases, disabled models, routing eligibility, and model metadata without duplicating these semantics in UI code.
+
+The current model-related data is spread across `crates/oxmux/src/routing.rs`, `crates/oxmux/src/configuration/file.rs`, `crates/oxmux/src/provider.rs`, and `crates/oxmux/src/protocol.rs`. The new contract should assemble those inputs into a deterministic headless catalog while preserving the existing split: routing selects a target for a request, provider execution talks to selected providers, and the registry lists what the configured core can offer.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Define Rust-native model registry and model listing types for configured models, provider-native model targets, aliases, forks, provider/account applicability, routing eligibility, streaming capability, and disabled/degraded state.
+- Build the first registry from deterministic `oxmux` inputs: validated file configuration, routing policy model routes, provider declarations, provider/account summaries, and explicit capability metadata.
+- Preserve both user-facing names and provider-native model targets so future `/v1/models`, routing explanations, reasoning controls, and app-shell pickers can explain alias/fork behavior.
+- Keep registry construction and tests networkless, provider-SDK-free, GPUI-free, OAuth-free, and independent from platform credential storage.
+- Document the future `/v1/models` route as a serialization consumer of the typed registry, not as a separate source of model semantics.
+
+**Non-Goals:**
+
+- No live provider model discovery, provider-specific scraping, remote model updater, background refresh task, or network call.
+- No real provider adapter behavior or provider SDK integration.
+- No GPUI model picker, app-shell model registry, desktop settings UX, tray/menu behavior, updater, or platform credential storage.
+- No broad request rewrite or reasoning/thinking control semantics; Issue #27 owns reasoning controls and may consume registry capability metadata later.
+- No full HTTP `/v1/models` route unless a later task explicitly scopes it as thin serialization over the typed registry.
+
+## Decisions
+
+1. Add a focused `model_registry` core module instead of extending routing or provider files.
+   - Rationale: registry entries combine routing, provider, protocol, and configuration concepts. Keeping them in a focused module avoids turning `routing.rs` or `provider.rs` into god-files and leaves route selection/provider execution responsibilities clear.
+   - Alternative considered: add registry structs to `routing.rs`. Rejected because listing is catalog behavior, not route selection.
+   - Alternative considered: add registry structs to `provider.rs`. Rejected because aliases and configured route groups are not provider execution state.
+
+2. Treat the registry as configured catalog data, not live provider inventory.
+   - Rationale: Issue #26 explicitly excludes remote updaters, provider scraping, and real provider calls. A deterministic catalog lets tests prove behavior and gives future UI/API surfaces stable data without requiring credentials or network availability.
+   - Alternative considered: query providers during listing. Rejected because it would entangle model listing with auth/session, quota, credentials, and network failures before those phases are ready.
+
+3. Represent aliases and forks explicitly instead of flattening them into model IDs.
+   - Rationale: provider access UX needs to explain requested names, alias resolution, forked provider/account targets, and provider-native models. Flattening would hide why a model appears multiple times or why a route is disabled/degraded.
+   - Alternative considered: expose only OpenAI-style `id` strings. Rejected because `/v1/models` compatibility is only one consumer; core and app-shell consumers need typed metadata.
+
+4. Keep routing selection authoritative while the registry reports routing eligibility.
+   - Rationale: existing `RoutingPolicy` already owns alias resolution, explicit provider/account targets, fallback behavior, and degraded/exhausted selection results. The registry should surface whether an entry is eligible or disabled/degraded, but actual per-request selection remains in routing.
+   - Alternative considered: make registry perform route selection. Rejected because it would duplicate and drift from `oxmux-routing-policy`.
+
+5. Define future `/v1/models` output as a projection of registry entries.
+   - Rationale: OpenAI-compatible clients expect a model listing shape, but core typed data should remain the source of truth. A future route can serialize visible/routable entries without introducing endpoint-only semantics.
+   - Alternative considered: implement `/v1/models` first and infer types from JSON. Rejected because it would bias core semantics toward one protocol family and make non-OpenAI providers harder to represent.
+
+6. Treat OpenAI model listing as the minimum compatibility projection, not the full registry model.
+   - Rationale: OpenAI-style listings are intentionally thin, while Anthropic and Gemini expose richer model metadata such as display names, token limits, capabilities, supported generation methods, and version stability. `oxmux` should keep richer provider-neutral metadata typed locally so future OpenAI, Claude, Gemini, and provider-specific projections can each serialize what they support.
+   - Alternative considered: limit registry entries to OpenAI-style `id` and ownership fields. Rejected because it would erase provider access UX metadata needed for aliases, forks, disabled/degraded state, streaming support, and future reasoning capability checks.
+
+## Risks / Trade-offs
+
+- [Risk] Registry entries become too broad before real providers exist. → Mitigation: keep the first implementation deterministic and limited to configured/provider-supplied metadata already represented in core types.
+- [Risk] Alias/fork terminology overlaps with routing policy language. → Mitigation: specs require preserving requested alias, resolved model, and provider-native model target separately, while route selection stays in routing.
+- [Risk] Future `/v1/models` consumers expect live provider data. → Mitigation: document listing as configured catalog data and include unknown/unavailable states rather than pretending live discovery happened.
+- [Risk] Capability flags drift from provider execution metadata. → Mitigation: derive streaming/protocol/auth/routing capability from provider declarations and summaries, and cover the mapping with tests.
+- [Risk] Adding a new module increases facade surface. → Mitigation: keep types small, document public API, and verify dependency-boundary tests still exclude `oxidemux`, GPUI, provider SDKs, OAuth, and network clients.
+
+## Migration Plan
+
+- Add specs and tests before implementation.
+- Implement model registry types and deterministic builders inside `crates/oxmux` without changing existing routing/proxy behavior.
+- Export registry primitives through `crates/oxmux/src/oxmux.rs` once tests cover direct Rust consumer usage.
+- Leave existing configuration and routing behavior compatible; no runtime migration or data migration is required.
+- If implementation reveals a non-trivial `/v1/models` route requirement, defer route wiring to a follow-up OpenSpec change or a clearly scoped later task in this change.
+
+## Open Questions
+
+- Exact public type names should be chosen during implementation to align with existing `oxmux` naming style.
+- The first implementation should decide whether disabled/degraded model state is represented as a single enum or as separate eligibility and reason fields, based on the smallest testable Rust API.

--- a/openspec/changes/add-oxmux-model-registry-listing/proposal.md
+++ b/openspec/changes/add-oxmux-model-registry-listing/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Issue #26 needs `oxmux` to expose a typed model registry and listing contract before provider adapters, reasoning controls, and app-shell model pickers depend on model metadata. Existing routing, provider, protocol, and file-configuration primitives can identify configured providers, provider accounts, model routes, aliases, protocol families, routing eligibility, streaming capability, and degraded state, but there is not yet a single headless catalog that answers "what models can this core configuration offer?"
+
+The registry must support provider access UX without becoming live provider discovery. Clients and the future `oxidemux` shell should consume deterministic `oxmux` registry data instead of inventing endpoint-only `/v1/models` semantics, duplicating app-owned model lists, scraping providers, or making network calls during model listing.
+
+## What Changes
+
+- Add a headless `oxmux` model registry/listing contract for configured model entries, provider-native model targets, aliases, forks, capability metadata, routing eligibility, disabled/degraded status, and provider/account applicability.
+- Derive the first implementation from deterministic file-backed configuration, routing policy, provider declarations, provider/account summaries, and streaming capability metadata already owned by `oxmux`.
+- Define how a future OpenAI-compatible `/v1/models` route serializes from the typed registry without making endpoint-specific model semantics the source of truth.
+- Preserve routing-policy ownership: the registry describes and validates listing/eligibility metadata while routing selection remains in the routing policy primitives.
+- Preserve scope boundaries: no provider scraping, remote model updater, real provider network calls, GPUI picker, app-shell model catalog, OAuth, platform credential storage, or provider SDK integration in this change.
+
+## Capabilities
+
+### New Capabilities
+
+- `oxmux-model-registry`: Defines typed model registry entries, alias/fork metadata, provider/account applicability, listing filters, static config-backed registry construction, and future `/v1/models` serialization semantics for the reusable core.
+
+### Modified Capabilities
+
+- `oxmux-core`: Public core API surface SHALL expose model registry/listing primitives without introducing app-shell, provider SDK, outbound network, OAuth, credential storage, or UI dependencies.
+- `oxmux-file-configuration`: Validated file-backed configuration SHALL provide deterministic inputs for static model registry entries and alias/fork listing tests.
+- `oxmux-routing-policy`: Routing policy aliases, model routes, fallback eligibility, and provider/account targets SHALL remain the source of route-selection truth while supplying model registry metadata.
+- `oxmux-management-lifecycle`: Management snapshots MAY surface model registry summaries in future changes, but this change only defines the reusable core model registry semantics unless explicitly scoped otherwise.
+
+## Impact
+
+- Affected crate: `crates/oxmux`.
+- Affected specs: `oxmux-core`, new `oxmux-model-registry`, and focused deltas to `oxmux-file-configuration` and `oxmux-routing-policy`.
+- Affected tests: new model registry tests plus targeted file-configuration/routing tests for static config-backed entries, alias preservation, fork behavior, disabled/degraded status, and streaming capability metadata.
+- Deferred work: concrete HTTP `/v1/models` route wiring, live provider model discovery, model updater jobs, app-shell model picker UX, provider-specific scraping, and real provider network calls.

--- a/openspec/changes/add-oxmux-model-registry-listing/specs/oxmux-core/spec.md
+++ b/openspec/changes/add-oxmux-model-registry-listing/specs/oxmux-core/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Minimal public facade for future core domains
+The `oxmux` crate SHALL expose a small public facade that establishes ownership of proxy lifecycle, local health runtime, local client authorization, provider/auth, provider execution, model registry/listing, routing, protocol translation, configuration, streaming, management/status, usage/quota, domain error primitives, and a minimal concrete proxy request smoke path without implementing full provider SDK integration, outbound provider calls, credential storage, full proxy request handling, remote management panels, provider scraping, remote model updater jobs, concrete `/v1/models` HTTP route behavior, or real streaming transport adapters in this change.
+
+#### Scenario: Provider auth ownership is visible but not implemented
+- **WHEN** maintainers inspect the `oxmux` public API or documentation
+- **THEN** provider authentication and token refresh are identified as future core concerns without requiring OAuth UI, platform credential storage, or concrete provider clients in this phase
+
+#### Scenario: Local client authorization ownership is visible
+- **WHEN** maintainers inspect the `oxmux` public API or documentation after adding local client authorization boundaries
+- **THEN** local proxy client authorization, inference access, management/status/control access, redacted local client credential metadata, and structured unauthorized outcomes are represented as headless core concerns without requiring GPUI, desktop credential storage, OAuth UI, provider SDKs, or app-shell state
+
+#### Scenario: Provider execution ownership exposes deterministic mock boundaries
+- **WHEN** maintainers inspect the `oxmux` public API or documentation after adding provider execution primitives
+- **THEN** provider execution is represented by trait, request, result, mock harness, and structured outcome primitives that can be used in deterministic tests without requiring real provider SDKs, HTTP clients, OAuth, platform credential storage, GPUI, or app-shell state
+
+#### Scenario: Model registry ownership exposes typed listing primitives
+- **WHEN** maintainers inspect the `oxmux` public API or documentation after adding model registry/listing primitives
+- **THEN** configured models, provider-native model targets, aliases, forks, provider/account applicability, routing eligibility, streaming support, disabled state, degraded state, and future `/v1/models` serialization semantics are represented by typed public primitives without requiring provider SDKs, outbound provider calls, provider scraping, remote model updater jobs, GPUI, or app-shell state
+
+#### Scenario: Routing ownership exposes typed policy primitives
+- **WHEN** maintainers inspect the `oxmux` public API or documentation after adding routing policy primitives
+- **THEN** model aliases, account targeting, priority, fallback, exhausted states, degraded states, selection outcomes, skipped candidate metadata, and routing failure details are represented by typed public primitives and exercised by the minimal smoke route without requiring full proxy routing behavior, provider SDKs, outbound provider calls, GPUI, or app-shell state
+
+#### Scenario: Protocol ownership exposes typed skeleton boundaries
+- **WHEN** maintainers inspect the `oxmux` public API or documentation
+- **THEN** OpenAI, Gemini, Claude, Codex, and provider-specific protocol translation are represented by typed request/response boundaries, typed protocol metadata, and deferred translation results while the minimal smoke route may construct an OpenAI canonical request without requiring full request translators, response translators, or outbound provider calls in this phase
+
+#### Scenario: Streaming ownership exposes typed response primitives
+- **WHEN** maintainers inspect the `oxmux` public API or documentation after adding streaming response primitives and robustness controls
+- **THEN** complete responses, streaming response events, streaming capability metadata, keepalive metadata, timeout metadata, retry-summary metadata, retry-exhaustion metadata, cancellation, terminal stream errors, and stream robustness policy are represented by typed public primitives without requiring real upstream streaming endpoints, WebSocket relay support, provider SDKs, outbound provider calls, GPUI, or app-shell state
+
+#### Scenario: Management ownership includes local health runtime status
+- **WHEN** maintainers inspect the `oxmux` public API or documentation after adding local health runtime behavior
+- **THEN** lifecycle, endpoint binding, health state, configuration snapshots, provider/account summaries, usage/quota summaries, local route protection metadata, latest streaming robustness outcome, warnings, and structured errors are represented as core management concerns without requiring GPUI, tray, updater, packaging, platform credential storage, or app-shell state

--- a/openspec/changes/add-oxmux-model-registry-listing/specs/oxmux-file-configuration/spec.md
+++ b/openspec/changes/add-oxmux-model-registry-listing/specs/oxmux-file-configuration/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: File-backed configuration supplies model registry inputs
+Validated file-backed configuration SHALL provide deterministic model registry inputs from provider declarations, provider account declarations, routing defaults, routing default groups, and routing policy data without requiring live provider model discovery, provider SDKs, OAuth flows, credential storage, provider scraping, remote model updater jobs, GPUI, `oxidemux`, or outbound provider network calls.
+
+#### Scenario: Routing defaults produce model registry candidates
+- **WHEN** a valid TOML configuration declares provider accounts and `[[routing.defaults]]` entries for one model
+- **THEN** the validated configuration can supply deterministic model registry candidates for that model, preserving provider identifiers, optional account identifiers, routing default names, candidate order, and fallback metadata
+
+#### Scenario: Provider declarations supply protocol and eligibility metadata
+- **WHEN** a valid TOML configuration declares `[[providers]]` entries with `protocol-family` and `routing-eligible` values
+- **THEN** model registry construction can attach provider family and routing eligibility metadata to entries derived from those providers
+
+#### Scenario: File-backed registry construction preserves strict validation
+- **WHEN** TOML configuration contains unknown fields or invalid provider/account/routing references while preparing model registry inputs
+- **THEN** validation fails through existing structured configuration errors instead of deferring invalid registry state to listing time
+
+#### Scenario: Credential references remain redacted
+- **WHEN** model registry entries are built from provider account declarations that include credential references
+- **THEN** registry metadata may identify account applicability but MUST NOT expose raw credential material or require credential lookup during registry construction

--- a/openspec/changes/add-oxmux-model-registry-listing/specs/oxmux-model-registry/spec.md
+++ b/openspec/changes/add-oxmux-model-registry-listing/specs/oxmux-model-registry/spec.md
@@ -1,0 +1,72 @@
+## ADDED Requirements
+
+### Requirement: Typed model registry entries
+The `oxmux` core SHALL expose typed model registry entries that represent configured model identifiers, provider-native model targets, aliases, forks, provider family, provider/account applicability, routing eligibility, streaming support, disabled state, degraded state, and human-readable reasons without requiring `oxidemux`, GPUI, provider SDKs, OAuth flows, platform credential storage, provider scraping, remote model updater jobs, or outbound provider network calls.
+
+#### Scenario: Registry entry preserves model identity layers
+- **WHEN** a Rust consumer inspects a model registry entry built from configured routing and provider metadata
+- **THEN** the entry exposes the user-facing listed model identifier separately from the provider-native model identifier and any alias or fork metadata
+
+#### Scenario: Registry entry exposes provider access metadata
+- **WHEN** a registry entry is associated with a provider and account declaration
+- **THEN** the entry exposes provider family, provider identifier, optional account identifier, routing eligibility, streaming support, disabled or degraded state, and reasons without exposing raw credentials or requiring live provider access
+
+#### Scenario: Registry remains headless
+- **WHEN** maintainers inspect or test model registry primitives
+- **THEN** the `oxmux` crate remains free of `oxidemux`, GPUI, provider SDK, OAuth, platform credential storage, provider scraping, remote updater, and outbound network dependencies
+
+### Requirement: Deterministic model registry listing
+The `oxmux` core SHALL provide deterministic model registry listing behavior that can return all configured entries, visible/routable entries, disabled entries, and degraded entries from in-memory core inputs without performing routing selection or provider execution.
+
+#### Scenario: Listing returns configured entries deterministically
+- **WHEN** a Rust consumer builds a registry from the same validated configuration, routing policy, provider summaries, and capability metadata twice
+- **THEN** `oxmux` returns the same ordered model registry entries both times
+
+#### Scenario: Listing distinguishes visible and disabled entries
+- **WHEN** configured model metadata includes disabled or routing-ineligible entries
+- **THEN** model listing preserves those entries with disabled or ineligible state instead of silently dropping them from the full registry
+
+#### Scenario: Listing does not perform route selection
+- **WHEN** a Rust consumer lists registry entries for a model that has multiple candidate providers or accounts
+- **THEN** the listing reports the candidate entries and eligibility metadata without selecting a runtime route or mutating fallback state
+
+### Requirement: Alias and fork metadata preservation
+The `oxmux` core SHALL preserve alias and fork metadata so model listing consumers can explain how a requested model name maps to one or more provider/account/model targets.
+
+#### Scenario: Alias listing preserves requested and resolved names
+- **WHEN** a routing policy maps a requested model alias to a resolved model identifier
+- **THEN** the model registry entry exposes both the alias and the resolved model identifier without requiring callers to parse a flattened model string
+
+#### Scenario: Fork listing preserves multiple targets
+- **WHEN** one listed model can route to multiple provider or account candidates
+- **THEN** the model registry exposes those provider/account targets as distinct candidate metadata while preserving the shared listed model identity
+
+#### Scenario: Alias metadata supports future reasoning controls
+- **WHEN** future reasoning or thinking controls inspect registry metadata
+- **THEN** they can consume typed alias and capability metadata without implementing model alias parsing in `oxidemux` or provider-specific adapters
+
+### Requirement: Future model listing route serialization
+The `oxmux` core SHALL define future `/v1/models` serialization semantics as a projection of typed model registry entries rather than a separate endpoint-owned model catalog.
+
+#### Scenario: OpenAI-compatible model listing uses registry data
+- **WHEN** a future local proxy route serializes an OpenAI-compatible `/v1/models` response
+- **THEN** the route derives listed model identifiers and metadata from typed model registry entries
+
+#### Scenario: OpenAI-compatible projection remains minimal
+- **WHEN** a future local proxy route serializes an OpenAI-compatible `/v1/models` response
+- **THEN** the projection can emit OpenAI-compatible model identifiers without dropping richer typed registry metadata needed by non-OpenAI protocol families and core consumers
+
+#### Scenario: Serialization omits live discovery assumptions
+- **WHEN** a model registry entry was built from static configuration or unknown provider/account state
+- **THEN** future route serialization does not imply that upstream provider discovery, credential validation, quota checks, or live network calls occurred
+
+### Requirement: Model registry tests remain networkless
+Default `oxmux` model registry tests SHALL use deterministic in-memory or file-backed fixtures and SHALL NOT require real providers, real credentials, OAuth flows, provider SDKs, GPUI, `oxidemux`, platform credential storage, provider scraping, remote updater jobs, or outbound provider network calls.
+
+#### Scenario: Tests cover static config-backed registry data
+- **WHEN** `cargo test -p oxmux` runs model registry tests
+- **THEN** tests cover static config-backed registry construction, provider/account metadata, routing eligibility, streaming capability, disabled or degraded state, and listing order without network access
+
+#### Scenario: Tests cover alias and fork behavior
+- **WHEN** `cargo test -p oxmux` runs model registry tests
+- **THEN** tests cover alias preservation, resolved model identity, and multiple provider/account fork metadata without invoking route selection or provider execution

--- a/openspec/changes/add-oxmux-model-registry-listing/specs/oxmux-routing-policy/spec.md
+++ b/openspec/changes/add-oxmux-model-registry-listing/specs/oxmux-routing-policy/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Routing policy supplies model registry metadata
+Routing policy primitives SHALL supply model registry construction with alias, resolved-model, route group, provider/account target, fallback, and candidate-order metadata while preserving routing selection as a separate operation.
+
+#### Scenario: Registry construction consumes aliases without selecting a route
+- **WHEN** a routing policy contains a model alias and one or more routes for the resolved model
+- **THEN** model registry construction can expose the alias and resolved model metadata without evaluating provider availability or selecting a target
+
+#### Scenario: Registry construction preserves candidate order
+- **WHEN** a routing policy contains multiple candidates for the same resolved model
+- **THEN** model registry construction preserves deterministic candidate order for listing and fork metadata
+
+#### Scenario: Registry construction does not mutate routing policy
+- **WHEN** a Rust consumer builds model registry entries from a routing policy
+- **THEN** the routing policy remains reusable for later `RoutingBoundary::select` calls without mutated fallback, availability, or skipped-candidate state
+
+#### Scenario: Registry metadata distinguishes eligibility from selection
+- **WHEN** a candidate is routing-ineligible, disabled, degraded, or unavailable according to supplied metadata
+- **THEN** the registry exposes that listing state while route selection continues to return routing-specific selection results or structured routing failures

--- a/openspec/changes/add-oxmux-model-registry-listing/tasks.md
+++ b/openspec/changes/add-oxmux-model-registry-listing/tasks.md
@@ -1,0 +1,35 @@
+## 1. Model Registry Contracts
+
+- [x] 1.1 Add a focused `crates/oxmux/src/model_registry.rs` module with typed registry entry, listed model identity, provider-native target, alias/fork metadata, provider/account applicability, capability, disabled/degraded state, and listing filter primitives.
+- [x] 1.2 Keep model registry primitives headless and dependency-light, avoiding `oxidemux`, GPUI, provider SDKs, OAuth, platform credential storage, provider scraping, remote updater jobs, HTTP clients, or outbound network calls.
+- [x] 1.3 Export the model registry primitives from `crates/oxmux/src/oxmux.rs` for direct Rust consumers while preserving existing public facade behavior.
+- [x] 1.4 Add public Rust documentation for all new public model registry types and constructors.
+
+## 2. Static Registry Construction
+
+- [x] 2.1 Implement deterministic registry construction from existing `RoutingPolicy`, `ModelAlias`, `ModelRoute`, `RoutingCandidate`, provider declarations, provider summaries, and protocol family metadata.
+- [x] 2.2 Add construction helpers for validated file-backed configuration so routing defaults, routing default groups, provider identifiers, account identifiers, protocol families, routing eligibility, and streaming capability can produce static registry entries.
+- [x] 2.3 Preserve user-facing model identifier, resolved model identifier, provider-native model identifier, alias metadata, and fork/candidate metadata without flattening them into one string.
+- [x] 2.4 Represent disabled, routing-ineligible, degraded, and unknown-provider/account states as listing metadata without performing route selection or provider execution.
+
+## 3. Listing and Future Route Semantics
+
+- [x] 3.1 Add deterministic listing APIs for all configured entries, visible/routable entries, disabled entries, and degraded entries without mutating routing policy state.
+- [x] 3.2 Define an OpenAI-compatible `/v1/models` serialization projection over typed registry entries without wiring a full HTTP route unless it remains a thin, explicitly scoped serializer.
+- [x] 3.3 Ensure model listing does not imply live provider discovery, credential validation, quota checks, upstream availability checks, or provider network access.
+- [x] 3.4 Keep routing selection in `RoutingBoundary::select`; registry construction and listing may consume routing metadata but must not duplicate route-selection outcomes.
+
+## 4. Deterministic Test Coverage
+
+- [x] 4.1 Add `crates/oxmux/tests/model_registry.rs` coverage for constructing static registry entries from in-memory routing/provider/protocol metadata.
+- [x] 4.2 Add tests proving file-backed configuration can produce deterministic registry entries with provider/account applicability, routing eligibility, streaming support, disabled/degraded metadata, and stable listing order.
+- [x] 4.3 Add tests proving aliases preserve requested and resolved model identifiers, and forked candidates preserve multiple provider/account targets under one listed model identity.
+- [x] 4.4 Add tests proving listing filters distinguish all configured entries, visible/routable entries, disabled entries, and degraded entries without invoking route selection or provider execution.
+- [x] 4.5 Add or update dependency-boundary tests to prove model registry primitives remain free of app-shell, GPUI, provider SDK, OAuth, credential storage, provider scraping, remote updater, and outbound network dependencies.
+
+## 5. Verification
+
+- [x] 5.1 Run `openspec validate add-oxmux-model-registry-listing --strict` and fix any OpenSpec validation issues.
+- [x] 5.2 Run `cargo fmt --all --check` and fix formatting issues.
+- [x] 5.3 Run `cargo test -p oxmux` and fix model registry/core test failures.
+- [x] 5.4 Run `mise run ci` to verify workspace formatting, checking, clippy, tests, and documentation checks.


### PR DESCRIPTION
## 🔗 Linked Issue

Closes #26

## ✅ Type of Change

- [x] ✨ New Project/Feature
- [ ] 🐞 Bug Fix
- [ ] 📚 Documentation Update
- [ ] 🔨 Refactor or Other

## 📝 Summary

- Adds a headless `oxmux` model registry API for typed model identities, aliases, forks, provider/account applicability, capabilities, and disabled/degraded/unknown listing states.
- Provides deterministic builders from routing policy and validated file configuration, plus a minimal OpenAI-compatible model-list projection without wiring an HTTP route.
- Adds model registry and dependency-boundary tests covering deterministic listing, filters, aliases/forks, file-backed disabled/degraded metadata, fallback metadata, and unknown accounts.

## 📐 OpenSpec Evidence

- OpenSpec change/spec: `openspec/changes/add-oxmux-model-registry-listing`
- No OpenSpec required: N/A
- Vision/boundary impact: Preserves `oxmux` as the shared headless owner for model registry/listing semantics while keeping `oxidemux`, GPUI, provider SDKs, OAuth, credential storage, live provider discovery, and outbound network behavior out of scope.

## 📖 Documentation Checklist

- [x] I updated `README.md`, `CONTRIBUTING.md`, or OpenSpec docs when needed.
- [x] I updated `CHANGELOG.md` for notable user-facing, compatibility, security, or workflow changes, or explained why it was not applicable.
  - Changelog not applicable: this is pre-release core API groundwork tracked by OpenSpec, with no user-facing release note yet.

## ✔️ Contributor Checklist

- [x] My code follows the project's coding standards.
- [x] I have added a `.env.example` file if environment variables are needed and ensured no secrets are committed.
  - Not applicable: no environment variables or secrets were added.
- [x] My pull request is focused on a single project or change.
- [x] I preserved the `oxmux` shared-core and `oxidemux` platform-shell boundary, or documented the OpenSpec-approved reason for changing it.
- [x] I ran `mise run ci` locally, or explained why it was not applicable.
- [x] I ran `mise run security` locally for dependency policy and vulnerability changes, or explained why it was not applicable.
  - Not applicable: no dependency or vulnerability-policy changes were made.
- [x] I ran relevant hk checks with `mise run hk-check`, or explained why they were not applicable.
  - Not applicable: `mise run ci` covered formatting, checking, clippy, tests, and docs for this code-only change.

## 💬 Additional Comments

Verification run locally:

- `openspec validate add-oxmux-model-registry-listing --strict`
- `cargo fmt --all --check`
- `cargo test -p oxmux`
- `mise run ci`
- LSP diagnostics on modified Rust files: clean
- Oracle review findings addressed before commit

Release Notes:

- N/A

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/WeShipWork/codesmith/oxidemux/pr/44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->